### PR TITLE
Issue 27

### DIFF
--- a/lib/SparkPost/SparkPost.php
+++ b/lib/SparkPost/SparkPost.php
@@ -40,11 +40,6 @@ class SparkPost {
    *              its just they API Key.
    */
   public function __construct($httpAdapter, $settingsConfig) {
-    // if the config map is a string we should assume that its an api key
-    if (gettype($settingsConfig) === 'string') {
-      $settingsConfig = ['key'=>$settingsConfig];
-    }
-
     //config needs to be setup before adapter because of default adapter settings
     $this->setConfig($settingsConfig);
     $this->setHttpAdapter($httpAdapter);
@@ -114,10 +109,17 @@ class SparkPost {
 
   /**
    * Allows the user to pass in values to override the defaults and set their API key
-   * @param Array $settingsConfig - Hashmap that contains config values for the SDK to connect to SparkPost
+   * @param String | Array $settingsConfig - Hashmap that contains config values
+   *              for the SDK to connect to SparkPost. If its a string we assume that
+   *              its just they API Key.
    * @throws \Exception
    */
-  public function setConfig(Array $settingsConfig) {
+  public function setConfig($settingsConfig) {
+    // if the config map is a string we should assume that its an api key
+    if (gettype($settingsConfig) === 'string') {
+      $settingsConfig = ['key'=>$settingsConfig];
+    }
+
     // Validate API key because its required
     if (!isset($settingsConfig['key']) || empty(trim($settingsConfig['key']))){
       throw new \Exception('You must provide an API key');

--- a/lib/SparkPost/SparkPost.php
+++ b/lib/SparkPost/SparkPost.php
@@ -2,7 +2,7 @@
 namespace SparkPost;
 
 class SparkPost {
-	
+
 	private static $config;
 	private static $defaults = array(
 			'host'=>'api.sparkpost.com',
@@ -10,23 +10,29 @@ class SparkPost {
 			'port'=>443,
 			'strictSSL'=>true,
 			'key'=>'',
-			'version'=>'v1'	
+			'version'=>'v1'
 		);
-	
+
 	/**
 	 * Enforce that this object can't be instansiated
 	 */
 	private function __construct(){}
-	
+
 	/**
 	 * Allows the user to pass in values to override the defaults and set their API key
-	 * @param Array $configMap - Hashmap that contains config values for the SDK to connect to SparkPost
+	 * @param String | Array $config - if a string it is an api key
+   *     If an array, is should contain config values for the SDK to connect to SparkPost
 	 * @throws \Exception
 	 */
-	public static function setConfig(array $configMap) {
-		//check for API key because its required	
-		if (isset($configMap['key'])){
-			$key = trim($configMap['key']);
+	public static function setConfig($config) {
+    // if the config map is a string we should assume that its an api key
+    if (gettype($config) === 'string') {
+      $config = ['key'=>$config];
+    }
+
+		//check for API key because its required
+		if (isset($config['key'])){
+			$key = trim($config['key']);
 			if(empty($key)){
 				throw new \Exception('You must provide an API key');
 			}
@@ -34,24 +40,24 @@ class SparkPost {
 			throw new \Exception('You must provide an API key');
 		}
 		self::$config = self::$defaults;
-		foreach ($configMap as $configOption => $configValue) {
+		foreach ($config as $configOption => $configValue) {
 			if(key_exists($configOption, self::$config)) {
 				self::$config[$configOption] = $configValue;
 			}
 		}
 	}
-	
+
 	/**
 	 * Retrieves the configuration that was previously setup by the user
 	 * @throws \Exception
 	 */
 	public static function getConfig() {
-		if (self::$config === null) {	
+		if (self::$config === null) {
 			throw new \Exception('No configuration has been provided');
 		}
 		return self::$config;
 	}
-	
+
 	public static function unsetConfig() {
 		self::$config = NULL;
 	}

--- a/lib/SparkPost/SparkPost.php
+++ b/lib/SparkPost/SparkPost.php
@@ -116,7 +116,7 @@ class SparkPost {
    */
   public function setConfig($settingsConfig) {
     // if the config map is a string we should assume that its an api key
-    if (gettype($settingsConfig) === 'string') {
+    if (is_string($settingsConfig)) {
       $settingsConfig = ['key'=>$settingsConfig];
     }
 

--- a/test/unit/SparkPostTest.php
+++ b/test/unit/SparkPostTest.php
@@ -51,6 +51,12 @@ class SparkPostTest extends \PHPUnit_Framework_TestCase {
     $this->resource->setHttpAdapter(new \stdClass());
   }
 
+  public function testSetConfigStringKey() {
+    $this->resource->setConfig('a key');
+    $config = self::$utils->getProperty($this->resource, 'config');
+    $this->assertEquals('a key', $config['key']);
+  }
+
   /**
    * @expectedException Exception
    * @expectedExceptionMessageRegExp /API key/


### PR DESCRIPTION
Added the ability to pass in a string rather than an associative array to set an api key. Closes #27.