### PR TITLE
Improve APIResponseException class

### DIFF
--- a/lib/SparkPost/APIResource.php
+++ b/lib/SparkPost/APIResource.php
@@ -192,11 +192,19 @@ class APIResource {
       // Handle 4XX responses, 5XX responses will throw an HttpAdapterException
       if ($statusCode < 400) {
         return json_decode($response->getBody()->getContents(), true);
-      } else {
-        if ($statusCode === 404) {
-          throw new APIResponseException('The specified resource does not exist', 404);
-        }
-        throw new APIResponseException('Received bad response from ' . ucfirst($this->endpoint) . ' API: '. $statusCode );
+      }
+      elseif ($statusCode === 404) {
+        throw new APIResponseException('The specified resource does not exist', 404);
+      }
+      else {
+        $response = json_decode($response->getBody(), true);
+        throw new APIResponseException(
+          'Received bad response from ' . ucfirst($this->endpoint),
+          $statusCode,
+          isset($response['errors'][0]['message']) ? $response['errors'][0]['message'] : "",
+          isset($response['errors'][0]['code']) ? $response['errors'][0]['code'] : 0,
+          isset($response['errors'][0]['description']) ? $response['errors'][0]['description'] : ""
+        );
       }
     }
 
@@ -208,7 +216,7 @@ class APIResource {
         throw $exception;
       }
 
-      throw new APIResponseException('Unable to contact ' . ucfirst($this->endpoint) . ' API: '. $exception->getMessage());
+      throw new APIResponseException('Unable to contact ' . ucfirst($this->endpoint) . ' API: '. $exception->getMessage(), $exception->getCode());
     }
   }
 

--- a/lib/SparkPost/APIResponseException.php
+++ b/lib/SparkPost/APIResponseException.php
@@ -16,15 +16,15 @@ class APIResponseException extends \Exception {
   /**
    * @var string
    */
-  protected $apiMessageDescription;
+  protected $apiDescription;
 
   /**
    * Construct the exception.
    */
-  public function __construct($message = "", $code = 0, $apiMessage = "", $apiCode = 0, $apiMessageDescription = "") {
+  public function __construct($message = "", $code = 0, $apiMessage = "", $apiCode = 0, $apiDescription = "") {
     $this->apiMessage = $apiMessage;
     $this->apiCode = $apiCode;
-    $this->apiMessageDescription = $apiMessageDescription;
+    $this->apiDescription = $apiDescription;
     parent::__construct($message, $code);
   }
 
@@ -45,11 +45,11 @@ class APIResponseException extends \Exception {
   }
 
   /**
-   * Gets the Exception message
-   * @return string the Exception message as a string.
+   * Gets the Exception description
+   * @return string the Exception description as a string.
    */
-  public function getAPIMessageDescription() {
-    return $this->apiMessageDescription;
+  public function getAPIDescription() {
+    return $this->apiDescription;
   }
 
 }

--- a/lib/SparkPost/APIResponseException.php
+++ b/lib/SparkPost/APIResponseException.php
@@ -3,7 +3,53 @@
 namespace SparkPost;
 
 class APIResponseException extends \Exception {
+  /**
+   * @var string
+   */
+  protected $apiMessage;
+
+  /**
+   * @var int
+   */
+  protected $apiCode;
+
+  /**
+   * @var string
+   */
+  protected $apiMessageDescription;
+
+  /**
+   * Construct the exception.
+   */
+  public function __construct($message = "", $code = 0, $apiMessage = "", $apiCode = 0, $apiMessageDescription = "") {
+    $this->apiMessage = $apiMessage;
+    $this->apiCode = $apiCode;
+    $this->apiMessageDescription = $apiMessageDescription;
+    parent::__construct($message, $code);
+  }
+
+  /**
+   * Gets the Exception message
+   * @return string the Exception message as a string.
+   */
+  public function getAPIMessage() {
+    return $this->apiMessage;
+  }
+
+  /**
+   * Gets the API Exception code.
+   * @return int the exception code as integer.
+   */
+  public function getAPICode() {
+    return $this->apiCode;
+  }
+
+  /**
+   * Gets the Exception message
+   * @return string the Exception message as a string.
+   */
+  public function getAPIMessageDescription() {
+    return $this->apiMessageDescription;
+  }
 
 }
-
-?>

--- a/test/unit/APIResourceExceptionTest.php
+++ b/test/unit/APIResourceExceptionTest.php
@@ -1,0 +1,36 @@
+<?php
+namespace SparkPost\Test;
+use SparkPost\APIResponseException;
+
+class APIResourceExceptionTest extends \PHPUnit_Framework_TestCase {
+
+  private $message;
+  private $code;
+  private $description;
+  private $exception;
+
+  /**
+   * (non-PHPdoc)
+   * @before
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  public function setUp() {
+    $this->message = 'Test message';
+    $this->code = 400;
+    $this->description = 'Test description';
+    $this->exception = new APIResponseException(NULL, 0, $this->message, $this->code, $this->description);
+  }
+
+  public function testAPIMessage() {
+    $this->assertEquals($this->message, $this->exception->getAPIMessage());
+  }
+
+  public function testAPICode() {
+    $this->assertEquals($this->code, $this->exception->getAPICode());
+  }
+
+  public function testAPIDescription() {
+    $this->assertEquals($this->description, $this->exception->getAPIDescription());
+  }
+
+}

--- a/test/unit/APIResourceTest.php
+++ b/test/unit/APIResourceTest.php
@@ -113,11 +113,13 @@ class APIResourceTest extends \PHPUnit_Framework_TestCase {
 
   public function testAdapter4XXException() {
     try {
+      $testBody = ['errors'=>['my'=>'test']];
       $responseMock = Mockery::mock();
       $this->sparkPostMock->httpAdapter->shouldReceive('send')->
         once()->
         andReturn($responseMock);
       $responseMock->shouldReceive('getStatusCode')->andReturn(400);
+      $responseMock->shouldReceive('getBody')->andReturn(json_encode($testBody));
 
       $this->resource->get('test');
     }


### PR DESCRIPTION
Hi

I work on SparkPost module for Drupal. I had some troubles sending email and Exception message and Code doesn't really help to investigate what was the source of the problem. API response has quite nice error message handling so I've added arguments to APIResponseException definition to aggregate API error messages.

`__construct($message = "", $code = 0, $apiMessage = "", $apiCode = 0, $apiMessageDescription = "")`

where

`$message` is custom message, 
`$code` is HTTP status Code,
`$apiMessage` is API error message received from endpoint,
`$apiCode` is API error code received from endpoint, 
`$apiMessageDescription` is API error message description received from endpoint.

Nothing special but it should improve DX, fix #44 and is backward compatible.