### PR TITLE
Add missing support for inline images

### DIFF
--- a/lib/SparkPost/Transmission.php
+++ b/lib/SparkPost/Transmission.php
@@ -29,6 +29,7 @@ class Transmission extends APIResource {
     'customHeaders'=>'content.headers',
     'recipients'=>'recipients',
     'recipientList'=>'recipients.list_id',
+    'inlineImages'=>'content.inline_images',    
     'template'=>'content.template_id',
     'trackOpens'=>'options.open_tracking',
     'trackClicks'=>'options.click_tracking',


### PR DESCRIPTION
Additional mapping in Transmission::$parameterMappings to support inline images.