### PR TITLE
Add destroy method to remove scheduled transmission

### DIFF
--- a/lib/SparkPost/Transmission.php
+++ b/lib/SparkPost/Transmission.php
@@ -108,6 +108,17 @@ class Transmission extends APIResource {
   public function find($transmissionID) {
     return $this->get($transmissionID);
   }
+
+  /**
+   * Method for deleting a scheduled transmission
+    *  Wrapper method for a cleaner interface
+    *
+   * @param string $transmissionID Identifier of the transmission to deleted
+   * @return array result Result of delete, empty on success
+   */
+  public function destroy($transmissionID) {
+    return $this->delete($transmissionID);
+  }
 }
 
 ?>

--- a/test/unit/TransmissionTest.php
+++ b/test/unit/TransmissionTest.php
@@ -86,5 +86,19 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase {
     $this->assertEquals($responseBody, $this->resource->find('test'));
   }
 
+  public function testDelete() {
+    $responseMock = Mockery::mock();
+    $responseBody = [];
+    $this->sparkPostMock->httpAdapter->shouldReceive('send')->
+      once()->
+      with('/.*\/transmissions.*\/test/', 'DELETE', Mockery::type('array'), null)->
+      andReturn($responseMock);
+    $responseMock->shouldReceive('getStatusCode')->andReturn(200);
+
+    $responseMock->shouldReceive('getBody->getContents')->andReturn(json_encode($responseBody));
+
+    $this->assertEquals($responseBody, $this->resource->destroy('test'));
+  }
+
 }
 ?>


### PR DESCRIPTION
I'm not sure how I feel about the method being called `destroy` so I would welcome feedback. We could call it `delete` but then we have to match the function signature of the parent class and call `parent::delete`.

References #46 