### PR TITLE
support inline_css option, refs #62

### DIFF
--- a/README.md
+++ b/README.md
@@ -107,6 +107,7 @@ try {
 | trackOpens       | no          | Field for enabling/disabling transmission level open tracking  (default: true)                                             | Boolean          |
 | trackClicks      | no          | Field for enabling/disabling transmission level click tracking (default: true)                                             | Boolean          |
 | useDraftTemplate | no          | Field for allowing the sending of a transmission using a draft of a stored template (default: false)                       | Boolean          |
+| inlineCss        | no          | Field for enabling automatic CSS inlining (default: false)                                                                 | Boolean          |
 | replyTo          | no          | Field for specifying the email address that should be used when a recipient hits the reply button                          | String           |
 | subject          | yes         | Field for setting the subject line of a given transmission                                                                 | String           |
 | from             | yes**       | Field for setting the from line of a given transmission                                                                    | String or Object |

--- a/examples/transmission/send_transmission_all_fields.php
+++ b/examples/transmission/send_transmission_all_fields.php
@@ -30,6 +30,7 @@ try{
     ],
     'trackOpens'=>false,
     'trackClicks'=>false,
+    'inlineCss'=>false,
     'from'=>'From Envelope <from@sparkpostbox.com>',
     'html'=>'<p>Hello World! Your name is: {{name}}</p>',
     'text'=>'Hello World!',

--- a/lib/SparkPost/Transmission.php
+++ b/lib/SparkPost/Transmission.php
@@ -37,6 +37,7 @@ class Transmission extends APIResource {
     'text'=>'content.text',
     'trackClicks'=>'options.click_tracking',
     'trackOpens'=>'options.open_tracking',
+    'inlineCss'=>'options.inline_css',
     'transactional'=>'options.transactional',
     'useDraftTemplate'=>'use_draft_template'
   ];
@@ -82,6 +83,7 @@ class Transmission extends APIResource {
    *  'text': string,
    *  'trackClicks': boolean,
    *  'trackOpens': boolean,
+   *  'inlineCss': boolean,
    *  'transactional': boolean,
    *  'useDraftTemplate': boolean
    *


### PR DESCRIPTION
Adds support for the API option `inline_css`, named `inlineCss` on the php side of things.