### PR TITLE
Message Events

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -5,3 +5,4 @@
 test/output/
 examples/example-config.json
 .idea
+/composer.phar

--- a/AUTHORS.md
+++ b/AUTHORS.md
@@ -5,3 +5,4 @@ php-sparkpost is maintained by Message Systems.
 * Jordan Nornhold <jordan.nornhold@messagesystems.com>, @beardyman
 * Rich Leland <rich.leland@messagesystems.com>, @richleland
 * Matthew April <matthew.japril@gmail.com>
+* James Fellows <james.fellows@8-w.co.uk>

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,7 +3,8 @@ All notable changes to this project will be documented in this file.
 This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
-- All content has been released to date.
+- Message Events API added.
+- Transmission API now accepts a DateTime object for startDate
 
 ## [1.0.3] - 2016-03-25
 ### Added

--- a/lib/SparkPost/APIResource.php
+++ b/lib/SparkPost/APIResource.php
@@ -141,6 +141,7 @@ class APIResource {
     }
 
     if( !empty($options['query'])) {
+      // check each query element - if it's an array, implode it to match the API-accepted format
       foreach($options['query'] as &$element) {
         if(is_array($element)) {
           $element = implode(",", $element);

--- a/lib/SparkPost/APIResource.php
+++ b/lib/SparkPost/APIResource.php
@@ -112,11 +112,6 @@ class APIResource {
    * @return array Result of the request
    */
   public function get( $resourcePath=null, Array $query=[] ) {
-    foreach($query as $element) {
-      if(is_array($element)) {
-        
-      }
-    }
     return $this->callResource( 'get', $resourcePath, ['query'=>$query] );
   }
 
@@ -135,7 +130,8 @@ class APIResource {
   /**
    * assembles a URL for a request
    * @param string $resourcePath path after the initial endpoint
-   * @param array $options array with an optional value of query with values to build a querystring from.
+   * @param array $options array with an optional value of query with values to build a querystring from.  Any
+   *                        query elements that are themselves arrays will be imploded into a comma separated list. 
    * @return string the assembled URL
    */
   private function buildUrl($resourcePath, $options) {
@@ -145,6 +141,12 @@ class APIResource {
     }
 
     if( !empty($options['query'])) {
+      foreach($options['query'] as &$element) {
+        if(is_array($element)) {
+          $element = implode(",", $element);
+        }
+      }
+
       $queryString = http_build_query($options['query']);
       $url .= '?'.$queryString;
     }

--- a/lib/SparkPost/APIResource.php
+++ b/lib/SparkPost/APIResource.php
@@ -112,6 +112,11 @@ class APIResource {
    * @return array Result of the request
    */
   public function get( $resourcePath=null, Array $query=[] ) {
+    foreach($query as $element) {
+      if(is_array($element)) {
+        
+      }
+    }
     return $this->callResource( 'get', $resourcePath, ['query'=>$query] );
   }
 

--- a/lib/SparkPost/MessageEvent.php
+++ b/lib/SparkPost/MessageEvent.php
@@ -1,11 +1,27 @@
 <?php
 namespace SparkPost;
 
+/**
+ * SDK class for querying message events API
+ * @package SparkPost
+ */
+class MessageEvent extends APIResource
+{
+  public $endpoint = 'message-events';
 
-class MessageEvent extends APIResource {
-	public $endpoint = 'message-events';
-
-	public function search(Array $queryParams) {
-		return $this->get(null, $queryParams);
-	}
+  /**
+   * Method for issuing search requests to the Message Events API.
+   *
+   * The method passes-through all of the query parameters listed at
+   * @link https://developers.sparkpost.com/api/#/reference/message-events/events-documentation/search-for-message-events
+   *
+   * @param array $queryParams  The query parameters.  Note that a query parameter containing an array
+   * is collapsed into a comma-separated list.
+   *
+   * @return array The result of the query.
+   */
+  public function search(Array $queryParams)
+  {
+    return $this->get(null, $queryParams);
+  }
 }

--- a/lib/SparkPost/MessageEvent.php
+++ b/lib/SparkPost/MessageEvent.php
@@ -44,9 +44,9 @@ class MessageEvent extends APIResource
   }
 
   /**
-   * List an example of the event data that will be included in a response from the MessageEvent::search() method.
+   * List examples of the event data that will be included in a response from the MessageEvent::search() method.
    */
-  public function samples() {
-    return $this->get("events/samples", ["events" => "bounce"]);
+  public function samples(Array $events) {
+    return $this->get("events/samples", ["events"=>$events]);
   }
 }

--- a/lib/SparkPost/MessageEvent.php
+++ b/lib/SparkPost/MessageEvent.php
@@ -2,8 +2,9 @@
 namespace SparkPost;
 
 /**
- * SDK class for querying message events API
- * @package SparkPost
+ * SDK class for querying the Message Events API
+ *
+ * @see https://developers.sparkpost.com/api/#/reference/message-events
  */
 class MessageEvent extends APIResource
 {
@@ -12,7 +13,7 @@ class MessageEvent extends APIResource
   /**
    * Method for issuing search requests to the Message Events API.
    *
-   * The method passes-through all of the query parameters listed at
+   * The method passes-through all of the query parameters - the valid ones are listed at
    * @link https://developers.sparkpost.com/api/#/reference/message-events/events-documentation/search-for-message-events
    *
    * @param array $queryParams  The query parameters.  Note that a query parameter containing an array
@@ -22,6 +23,30 @@ class MessageEvent extends APIResource
    */
   public function search(Array $queryParams)
   {
+    // check for DateTime objects & replace them with the formatted string equivalent
+    foreach(["from", "to"] as $dateTimeParam) {
+      if (isset($queryParams[$dateTimeParam]) && $queryParams[$dateTimeParam] instanceof \DateTime) {
+        // the message events API doesn't allow the seconds or GMT offset, so strip them
+        $queryParams[$dateTimeParam] = substr($queryParams[$dateTimeParam]->format(\DateTime::ATOM), 0, 16);
+      }
+    }
+
     return $this->get(null, $queryParams);
+  }
+
+  /**
+   * List descriptions of the event fields that could be included in a response from the MessageEvent::search() method.
+   *
+   * @return array The event field descriptions.
+   */
+  public function documentation() {
+    return $this->get("events/documentation");
+  }
+
+  /**
+   * List an example of the event data that will be included in a response from the MessageEvent::search() method.
+   */
+  public function samples() {
+    return $this->get("events/samples", ["events" => "bounce"]);
   }
 }

--- a/lib/SparkPost/MessageEvent.php
+++ b/lib/SparkPost/MessageEvent.php
@@ -1,0 +1,11 @@
+<?php
+namespace SparkPost;
+
+
+class MessageEvent extends APIResource {
+	public $endpoint = 'message-events';
+
+	public function search(Array $queryParams) {
+		return $this->get(null, $queryParams);
+	}
+}

--- a/lib/SparkPost/MessageEvents.php
+++ b/lib/SparkPost/MessageEvents.php
@@ -6,8 +6,11 @@ namespace SparkPost;
  *
  * @see https://developers.sparkpost.com/api/#/reference/message-events
  */
-class MessageEvent extends APIResource
+class MessageEvents extends APIResource
 {
+  /**
+   * @var string
+   */
   public $endpoint = 'message-events';
 
   /**
@@ -45,8 +48,13 @@ class MessageEvent extends APIResource
 
   /**
    * List examples of the event data that will be included in a response from the MessageEvent::search() method.
+   *
+   * @param array $events (optional) Event types for which to get a sample payload.  If not provided, samples
+   * for all events will be returned.
+   *
+   * @return array Sample events.
    */
-  public function samples(Array $events) {
+  public function samples(Array $events = []) {
     return $this->get("events/samples", ["events"=>$events]);
   }
 }

--- a/lib/SparkPost/SparkPost.php
+++ b/lib/SparkPost/SparkPost.php
@@ -6,7 +6,7 @@ use Ivory\HttpAdapter\HttpAdapterInterface;
 class SparkPost {
 
   public $transmission;
-  public $messageEvent;
+  public $messageEvents;
 
   /**
    * Connection config for making requests.
@@ -46,7 +46,7 @@ class SparkPost {
     $this->setHttpAdapter($httpAdapter);
 
     $this->transmission = new Transmission($this);
-    $this->messageEvent = new MessageEvent($this);
+    $this->messageEvents = new MessageEvents($this);
   }
 
   /**

--- a/lib/SparkPost/SparkPost.php
+++ b/lib/SparkPost/SparkPost.php
@@ -6,6 +6,7 @@ use Ivory\HttpAdapter\HttpAdapterInterface;
 class SparkPost {
 
   public $transmission;
+  public $messageEvent;
 
   /**
    * Connection config for making requests.
@@ -45,6 +46,7 @@ class SparkPost {
     $this->setHttpAdapter($httpAdapter);
 
     $this->transmission = new Transmission($this);
+    $this->messageEvent = new MessageEvent($this);
   }
 
   /**

--- a/lib/SparkPost/Transmission.php
+++ b/lib/SparkPost/Transmission.php
@@ -75,7 +75,7 @@ class Transmission extends APIResource {
    *  'replyTo': string,
    *  'rfc822': string,
    *  'sandbox': boolean,
-   *  'startTime': string,
+   *  'startTime': string | \DateTime,
    *  'subject': string,
    *  'substitutionData': array,
    *  'template': string,
@@ -89,6 +89,13 @@ class Transmission extends APIResource {
    * @return array API repsonse represented as key-value pairs
    */
   public function send( $transmissionConfig ) {
+    if(isset($transmissionConfig["startTime"]) &&
+      $transmissionConfig["startTime"] instanceof \DateTime)
+      {
+        $transmissionConfig["startTime"] =
+          $transmissionConfig["startTime"]->format(\DateTime::ATOM);
+      }
+
     return $this->create( $transmissionConfig );
   }
 

--- a/lib/SparkPost/Transmission.php
+++ b/lib/SparkPost/Transmission.php
@@ -89,11 +89,9 @@ class Transmission extends APIResource {
    * @return array API repsonse represented as key-value pairs
    */
   public function send( $transmissionConfig ) {
-    if(isset($transmissionConfig["startTime"]) &&
-      $transmissionConfig["startTime"] instanceof \DateTime)
+    if(isset($transmissionConfig["startTime"]) && $transmissionConfig["startTime"] instanceof \DateTime)
       {
-        $transmissionConfig["startTime"] =
-          $transmissionConfig["startTime"]->format(\DateTime::ATOM);
+        $transmissionConfig["startTime"] = $transmissionConfig["startTime"]->format(\DateTime::ATOM);
       }
 
     return $this->create( $transmissionConfig );

--- a/test/unit/APIResourceTest.php
+++ b/test/unit/APIResourceTest.php
@@ -84,6 +84,20 @@ class APIResourceTest extends \PHPUnit_Framework_TestCase {
     $this->assertEquals($testBody, $this->resource->get('test'));
   }
 
+  public function testGetCommaSeparated() {
+    $testBody = ['results'=>['my'=>'test']];
+    $responseMock = Mockery::mock();
+    $this->sparkPostMock->httpAdapter->shouldReceive('send')->
+    once()->
+    with('/.*\/test/', 'GET', Mockery::type('array'), null)->
+    andReturn($responseMock);
+    $responseMock->shouldReceive('getStatusCode')->andReturn(200);
+    $responseMock->shouldReceive('getBody->getContents')->andReturn(json_encode($testBody));
+
+    $this->assertEquals($testBody, $this->resource->get(
+      'test', [ "param1" => "param1val", "param2" => ["param2val1", "param2val2"] ]));
+  }
+
   public function testDelete() {
     $responseMock = Mockery::mock();
     $this->sparkPostMock->httpAdapter->shouldReceive('send')->

--- a/test/unit/APIResourceTest.php
+++ b/test/unit/APIResourceTest.php
@@ -86,16 +86,21 @@ class APIResourceTest extends \PHPUnit_Framework_TestCase {
 
   public function testGetCommaSeparated() {
     $testBody = ['results'=>['my'=>'test']];
+    $requestArray = [
+        "param1" => "param1val",
+        "param2" => ["param2val1", "param2val2"]
+    ];
+    $expectedGetParams = "param1=param1val&param2=" . urlencode("param2val1,param2val2");
+
     $responseMock = Mockery::mock();
     $this->sparkPostMock->httpAdapter->shouldReceive('send')->
-    once()->
-    with('/.*\/test/', 'GET', Mockery::type('array'), null)->
-    andReturn($responseMock);
+      once()->
+      with(matchesPattern("/.*\/test\?{$expectedGetParams}/"), 'GET', Mockery::type('array'), null)->
+      andReturn($responseMock);
     $responseMock->shouldReceive('getStatusCode')->andReturn(200);
     $responseMock->shouldReceive('getBody->getContents')->andReturn(json_encode($testBody));
 
-    $this->assertEquals($testBody, $this->resource->get(
-      'test', [ "param1" => "param1val", "param2" => ["param2val1", "param2val2"] ]));
+    $this->assertEquals($testBody, $this->resource->get('test', $requestArray));
   }
 
   public function testDelete() {

--- a/test/unit/MessageEventTest.php
+++ b/test/unit/MessageEventTest.php
@@ -1,0 +1,45 @@
+<?php
+
+namespace SparkPost;
+
+use \Mockery;
+
+
+class MessageEventTest extends \PHPUnit_Framework_TestCase
+{
+  private $sparkPostMock;
+  private $sut;
+
+  /**
+   * (non-PHPdoc)
+   * @before
+   * @see PHPUnit_Framework_TestCase::setUp()
+   */
+  public function setUp()
+  {
+    $this->sparkPostMock = Mockery::mock('SparkPost\SparkPost', function ($mock) {
+      $mock->shouldReceive('getHttpHeaders')->andReturn([]);
+    });
+    $this->sparkPostMock->httpAdapter = Mockery::mock();
+    $this->sut = new MessageEvent($this->sparkPostMock);
+  }
+
+  public function testDateTimeConversion()
+  {
+    $testBody = ['results' => ['my' => 'test']];
+    $testFrom = new \DateTime("1978-08-27 04:05:02");
+    $testFromStr = urlencode("1978-08-27T04:05");
+    $testTo = new \DateTime("2016-04-04 19:00");
+    $testToStr = urlencode("2016-04-04T19:00");
+
+    $responseMock = Mockery::mock();
+    $this->sparkPostMock->httpAdapter->shouldReceive('send')->
+      once()->
+      with("/message-events/?from={$testFromStr}&to={$testToStr}", 'GET', Mockery::type('array'), null)->
+      andReturn($responseMock);
+    $responseMock->shouldReceive('getStatusCode')->andReturn(200);
+    $responseMock->shouldReceive('getBody->getContents')->andReturn(json_encode($testBody));
+
+    $this->assertEquals($testBody, $this->sut->search(["from" => $testFrom, "to" => $testTo]));
+  }
+}

--- a/test/unit/MessageEventTest.php
+++ b/test/unit/MessageEventTest.php
@@ -21,7 +21,7 @@ class MessageEventTest extends \PHPUnit_Framework_TestCase
       $mock->shouldReceive('getHttpHeaders')->andReturn([]);
     });
     $this->sparkPostMock->httpAdapter = Mockery::mock();
-    $this->sut = new MessageEvent($this->sparkPostMock);
+    $this->sut = new MessageEvents($this->sparkPostMock);
   }
 
   public function testDateTimeConversion()

--- a/test/unit/MessageEventTest.php
+++ b/test/unit/MessageEventTest.php
@@ -42,4 +42,30 @@ class MessageEventTest extends \PHPUnit_Framework_TestCase
 
     $this->assertEquals($testBody, $this->sut->search(["from" => $testFrom, "to" => $testTo]));
   }
+
+  public function testDocumentation() {
+    $testBody = ['results' => ['my' => 'test']];
+    $responseMock = Mockery::mock();
+    $this->sparkPostMock->httpAdapter->shouldReceive('send')->
+      once()->
+      with("/message-events/events/documentation", 'GET', Mockery::type('array'), null)->
+      andReturn($responseMock);
+    $responseMock->shouldReceive('getStatusCode')->andReturn(200);
+    $responseMock->shouldReceive('getBody->getContents')->andReturn(json_encode($testBody));
+
+    $this->assertEquals($testBody, $this->sut->documentation());
+  }
+
+  public function testSamples() {
+    $testBody = ['results' => ['my' => 'test']];
+    $responseMock = Mockery::mock();
+    $this->sparkPostMock->httpAdapter->shouldReceive('send')->
+      once()->
+      with("/message-events/events/samples?events=".urlencode("delivery,bounce"), 'GET', Mockery::type('array'), null)->
+      andReturn($responseMock);
+    $responseMock->shouldReceive('getStatusCode')->andReturn(200);
+    $responseMock->shouldReceive('getBody->getContents')->andReturn(json_encode($testBody));
+
+    $this->assertEquals($testBody, $this->sut->samples(["delivery", "bounce"]));
+  }
 }

--- a/test/unit/TransmissionTest.php
+++ b/test/unit/TransmissionTest.php
@@ -44,6 +44,22 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase {
     $this->assertEquals($responseBody, $this->resource->send($body));
   }
 
+  public function testSendDateTimeConversion()
+  {
+    $testStartTime = new \DateTime("2016-08-27 13:01:02", new \DateTimeZone("UTC"));
+
+    $responseMock = Mockery::mock();
+    $responseBody = ['results'=>'yay'];
+    $this->sparkPostMock->httpAdapter->shouldReceive('send')->
+      once()->
+      with('/.*\/transmissions/', 'POST', Mockery::type('array'), matchesPattern('/"start_time":"2016-08-27T13:01:02\+00:00"/'))->
+      andReturn($responseMock);
+    $responseMock->shouldReceive('getStatusCode')->andReturn(200);
+    $responseMock->shouldReceive('getBody->getContents')->andReturn(json_encode($responseBody));
+
+    $this->assertEquals($responseBody, $this->resource->send(['startTime'=>$testStartTime]));
+  }
+
   public function testAllWithFilter() {
     $responseMock = Mockery::mock();
     $responseBody = ['results'=>'yay'];


### PR DESCRIPTION
I've implemented the Message Events functionality, trying to keep to the same style of unit tests etc.  There are a couple of points of note/ for discussion:
  1. The Message Events API accepts a comma-separated list of values for each query parameter.  Given that it's potentially used elsewhere in the API, I added the implosion of an array query parameter in the base APIResource class (and augmented the unit tests to cover it).
  2. For some reason the Message Events API takes a date-time in a different format to the Transmission API (without seconds or UTC offset).  Rather than making the user mess with formatting these differently for each API call I added code to format a passed-in `\DateTime` object in each scenario.
  3. I've run manual integration tests against my own API key.  I'm a bit nervous/ surprised that there are no automated integration tests in the pack, particularly given that there's a mock API available on the SparkPost API documentation.  Is there a case to be made for adding some integration tests to this repo?

Closes #58 and #65 