### PR TITLE
Fix #83: Return status code on 403

### DIFF
--- a/lib/SparkPost/APIResource.php
+++ b/lib/SparkPost/APIResource.php
@@ -194,7 +194,7 @@ class APIResource {
         return json_decode($response->getBody()->getContents(), true);
       }
       elseif ($statusCode === 403) {
-        throw new APIResponseException('Request forbidden.  Does this API Key have the correct SparkPost permissions?');
+        throw new APIResponseException('Request forbidden.  Does this API Key have the correct SparkPost permissions?', 403);
       }
       elseif ($statusCode === 404) {
         throw new APIResponseException('The specified resource does not exist', 404);


### PR DESCRIPTION
That's the simplest way to fix #83. Would be better to add apiCode, apiMessage, and apiDescription if available.

ref. [Extended error codes](https://support.sparkpost.com/customer/en/portal/articles/2140916-extended-error-codes)