### PR TITLE
Return extended exception data

### DIFF
--- a/examples/transmission/delete_transmission.php
+++ b/examples/transmission/delete_transmission.php
@@ -17,6 +17,8 @@ try {
     $results = $sparky->transmission->delete('transmission-id');
     echo 'Transmission deleted!';
 } catch (\Exception $exception) {
-    echo $exception->getMessage();
+    echo $exception->getAPIMessage() . "\n";
+    echo $exception->getAPICode() . "\n";
+    echo $exception->getAPIDescription() . "\n";
 }
 ?>

--- a/examples/transmission/get_all_transmissions.php
+++ b/examples/transmission/get_all_transmissions.php
@@ -17,6 +17,8 @@ try {
     $results = $sparky->transmission->all();
     echo 'Congrats! You got a list of all your transmissions from SparkPost!';
 } catch (\Exception $exception) {
-    echo $exception->getMessage();
+    echo $exception->getAPIMessage() . "\n";
+    echo $exception->getAPICode() . "\n";
+    echo $exception->getAPIDescription() . "\n";
 }
 ?>

--- a/examples/transmission/get_transmission.php
+++ b/examples/transmission/get_transmission.php
@@ -17,6 +17,8 @@ try {
     $results = $sparky->transmission->find('Your Transmission ID');
     echo 'Congrats! You retrieved your transmission from SparkPost!';
 } catch (\Exception $exception) {
-    echo $exception->getMessage();
+    echo $exception->getAPIMessage() . "\n";
+    echo $exception->getAPICode() . "\n";
+    echo $exception->getAPIDescription() . "\n";
 }
 ?>

--- a/examples/transmission/rfc822.php
+++ b/examples/transmission/rfc822.php
@@ -26,6 +26,8 @@ try {
     ]);
     echo 'Congrats! You sent an email using SparkPost!';
 } catch (\Exception $exception) {
-    echo $exception->getMessage();
+    echo $exception->getAPIMessage() . "\n";
+    echo $exception->getAPICode() . "\n";
+    echo $exception->getAPIDescription() . "\n";
 }
 ?>

--- a/examples/transmission/send_transmission_all_fields.php
+++ b/examples/transmission/send_transmission_all_fields.php
@@ -61,6 +61,8 @@ try{
 
     echo 'Congrats! You sent an email using SparkPost!';
 } catch (\Exception $exception) {
-    echo $exception->getMessage();
+    echo $exception->getAPIMessage() . "\n";
+    echo $exception->getAPICode() . "\n";
+    echo $exception->getAPIDescription() . "\n";
 }
 ?>

--- a/examples/transmission/simple_send.php
+++ b/examples/transmission/simple_send.php
@@ -32,6 +32,8 @@ try {
     ]);
     echo 'Congrats! You sent an email using SparkPost!';
 } catch (\Exception $exception) {
-    echo $exception->getMessage();
+    echo $exception->getAPIMessage() . "\n";
+    echo $exception->getAPICode() . "\n";
+    echo $exception->getAPIDescription() . "\n";
 }
 ?>

--- a/examples/transmission/stored_recipients_inline_content.php
+++ b/examples/transmission/stored_recipients_inline_content.php
@@ -29,6 +29,8 @@ try {
 
     echo 'Congrats! You sent an email using SparkPost!';
 } catch (\Exception $exception) {
-    echo $exception->getMessage();
+    echo $exception->getAPIMessage() . "\n";
+    echo $exception->getAPICode() . "\n";
+    echo $exception->getAPIDescription() . "\n";
 }
 ?>

--- a/examples/transmission/stored_template_send.php
+++ b/examples/transmission/stored_template_send.php
@@ -30,6 +30,8 @@ try {
     ]);
     echo 'Congrats! You sent an email using SparkPost!';
 } catch (\Exception $exception) {
-    echo $exception->getMessage();
+    echo $exception->getAPIMessage() . "\n";
+    echo $exception->getAPICode() . "\n";
+    echo $exception->getAPIDescription() . "\n";
 }
 ?>

--- a/lib/SparkPost/APIResource.php
+++ b/lib/SparkPost/APIResource.php
@@ -131,7 +131,7 @@ class APIResource {
    * assembles a URL for a request
    * @param string $resourcePath path after the initial endpoint
    * @param array $options array with an optional value of query with values to build a querystring from.  Any
-   *                        query elements that are themselves arrays will be imploded into a comma separated list. 
+   *                        query elements that are themselves arrays will be imploded into a comma separated list.
    * @return string the assembled URL
    */
   private function buildUrl($resourcePath, $options) {
@@ -202,7 +202,14 @@ class APIResource {
         return json_decode($response->getBody()->getContents(), true);
       }
       elseif ($statusCode === 403) {
-        throw new APIResponseException('Request forbidden.  Does this API Key have the correct SparkPost permissions?');
+        $response = json_decode($response->getBody(), true);
+        throw new APIResponseException(
+          'Request forbidden',
+          $statusCode,
+          isset($response['errors'][0]['message']) ? $response['errors'][0]['message'] : "Request forbidden",
+          isset($response['errors'][0]['code']) ? $response['errors'][0]['code'] : 1100,
+          isset($response['errors'][0]['description']) ? $response['errors'][0]['description'] : "Does this API Key have the correct permissions?"
+        );
       }
       elseif ($statusCode === 404) {
         throw new APIResponseException('The specified resource does not exist', 404);

--- a/test/unit/APIResourceTest.php
+++ b/test/unit/APIResourceTest.php
@@ -131,12 +131,18 @@ class APIResourceTest extends \PHPUnit_Framework_TestCase {
   }
 
   public function testAdapter403Exception() {
+    $testBody = [ 'errors' => [
+      [
+        'message' => 'Forbidden.'
+      ]
+    ]];
     try {
       $responseMock = Mockery::mock();
       $this->sparkPostMock->httpAdapter->shouldReceive('send')->
       once()->
       andReturn($responseMock);
       $responseMock->shouldReceive('getStatusCode')->andReturn(403);
+      $responseMock->shouldReceive('getBody')->andReturn(json_encode($testBody));
 
       $this->resource->get('test');
     }


### PR DESCRIPTION
- Update to return message, code, and description from API (if available, with fallback) (thanks @zaporylie!)
- Update examples to use use extra methods available on the SparkPost exception class
- Fixes #83 