### PR TITLE
Added an option to overwrite the default 10 seconds timeout

### DIFF
--- a/examples/transmission/send_transmission_all_fields.php
+++ b/examples/transmission/send_transmission_all_fields.php
@@ -13,7 +13,7 @@ use GuzzleHttp\Client;
 use Ivory\HttpAdapter\Guzzle6HttpAdapter;
 
 $httpAdapter = new Guzzle6HttpAdapter(new Client());
-$sparky = new SparkPost($httpAdapter, ['key' => $config['api-key']]);
+$sparky = new SparkPost($httpAdapter, ['key' => $config['api-key'], 'timeout' => 0]]);
 
 $data = file_get_contents('/path/to/test.csv');
 

--- a/lib/SparkPost/SparkPost.php
+++ b/lib/SparkPost/SparkPost.php
@@ -35,6 +35,7 @@ class SparkPost
         'strictSSL' => true,
         'key' => '',
         'version' => 'v1',
+        'timeout' => 10
     ];
 
     /**
@@ -99,6 +100,7 @@ class SparkPost
         $httpConfig = new Configuration();
         $baseUrl = $config['protocol'].'://'.$config['host'].($config['port'] ? ':'.$config['port'] : '').'/api/'.$config['version'];
         $httpConfig->setBaseUri($baseUrl);
+        $httpConfig->setTimeout($this->config['timeout']);
         $httpConfig->setUserAgent('php-sparkpost/'.$this->version);
 
         return $httpConfig;


### PR DESCRIPTION
Added an option to overwrite the default 10 seconds timeout with any value. 
Please note I suggest we allow for an entire guzzle configuration to be passed in, as the current method of overwriting the configuration in the Sparkpost class brings confusion as the guzzle configurations that are passed into the wrapper originally are overwritten.

Fixes #106 , #107 , #109 

Please note there is an extra parameter that you can now pass into the sparkpost config array that looks like this:

`['key' => $config['api-key'], 'timeout' => 0]]`