### PR TITLE
Transmissions : makes "from" address optional for use with templates

### DIFF
--- a/lib/SparkPost/Transmission.php
+++ b/lib/SparkPost/Transmission.php
@@ -90,7 +90,9 @@ class Transmission extends Resource
      */
     private function formatShorthandRecipients($payload)
     {
-        $payload['content']['from'] = $this->toAddressObject($payload['content']['from']);
+        if (isset($payload['content']['from'])) {
+            $payload['content']['from'] = $this->toAddressObject($payload['content']['from']);
+        }
 
         for ($i = 0; $i < count($payload['recipients']); ++$i) {
             $payload['recipients'][$i]['address'] = $this->toAddressObject($payload['recipients'][$i]['address']);


### PR DESCRIPTION
Hello !

Thanks for the 2.0 update, it makes a lot of sense, and removes the deprecated Ivory dependency, so good ! :+1: 

Unfortunately, at the moment, it seems like adding a `From` address is a hard requirement, even when using templates (which you can set up the `From` address for in the Sparkpost UI).

This fixes this use case. I didn't dive to deep into the details : maybe there should be some additional checks in case we are *not* using a template, in which case a `From` would indeed be needed.

Just wanted to get feedback first.

Best regards,
Conrad @ reassurez-moi.fr