### PR TITLE
Remove dependency form Guzzle

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -15,14 +15,14 @@
     "fix-style": "php-cs-fixer fix ."
   },
   "require": {
-    "php": ">=5.5.0",
+    "php": "^5.5 || ^7.0",
+    "psr/http-message": "^1.0",
     "php-http/client-implementation": "^1.0",
-    "guzzlehttp/psr7": "1.3.*"
+    "php-http/discovery": "^1.0"
   },
   "require-dev": {
-    "guzzlehttp/guzzle": "6.*",
-    "php-http/guzzle6-adapter": "*",
-    "php-http/message": "*",
+    "php-http/guzzle6-adapter": "^1.0",
+    "php-http/message": "^1.0",
     "mockery/mockery": "^0.9.4",
     "fabpot/php-cs-fixer": "^1.11"
   },

--- a/composer.json
+++ b/composer.json
@@ -17,6 +17,7 @@
   "require": {
     "php": "^5.5 || ^7.0",
     "psr/http-message": "^1.0",
+    "php-http/httplug": "^1.0",
     "php-http/client-implementation": "^1.0",
     "php-http/discovery": "^1.0"
   },

--- a/composer.lock
+++ b/composer.lock
@@ -4,32 +4,32 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "7b514c4fd3556635eab6298f14e03c47",
-    "content-hash": "2a019c7c9fe0fa211dd763cb9c1bcd62",
+    "hash": "f3aa73ae7dde80f1176649ef01f86204",
+    "content-hash": "5714a77e64c935d51c3630dfc84eeb1b",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",
-            "version": "6.2.0",
+            "version": "6.2.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/guzzle.git",
-                "reference": "d094e337976dff9d8e2424e8485872194e768662"
+                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/d094e337976dff9d8e2424e8485872194e768662",
-                "reference": "d094e337976dff9d8e2424e8485872194e768662",
+                "url": "https://api.github.com/repos/guzzle/guzzle/zipball/3f808fba627f2c5b69e2501217bf31af349c1427",
+                "reference": "3f808fba627f2c5b69e2501217bf31af349c1427",
                 "shasum": ""
             },
             "require": {
-                "guzzlehttp/promises": "~1.0",
-                "guzzlehttp/psr7": "~1.1",
-                "php": ">=5.5.0"
+                "guzzlehttp/promises": "^1.0",
+                "guzzlehttp/psr7": "^1.3.1",
+                "php": ">=5.5"
             },
             "require-dev": {
                 "ext-curl": "*",
-                "phpunit/phpunit": "~4.0",
-                "psr/log": "~1.0"
+                "phpunit/phpunit": "^4.0",
+                "psr/log": "^1.0"
             },
             "type": "library",
             "extra": {
@@ -67,7 +67,7 @@
                 "rest",
                 "web service"
             ],
-            "time": "2016-03-21 20:02:09"
+            "time": "2016-07-15 17:22:37"
         },
         {
             "name": "guzzlehttp/promises",
@@ -122,16 +122,16 @@
         },
         {
             "name": "guzzlehttp/psr7",
-            "version": "1.3.0",
+            "version": "1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/guzzle/psr7.git",
-                "reference": "31382fef2889136415751badebbd1cb022a4ed72"
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/guzzle/psr7/zipball/31382fef2889136415751badebbd1cb022a4ed72",
-                "reference": "31382fef2889136415751badebbd1cb022a4ed72",
+                "url": "https://api.github.com/repos/guzzle/psr7/zipball/5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
+                "reference": "5c6447c9df362e8f8093bda8f5d8873fe5c7f65b",
                 "shasum": ""
             },
             "require": {
@@ -147,7 +147,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.0-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -176,7 +176,69 @@
                 "stream",
                 "uri"
             ],
-            "time": "2016-04-13 19:56:01"
+            "time": "2016-06-24 23:00:38"
+        },
+        {
+            "name": "php-http/discovery",
+            "version": "v1.0.0",
+            "source": {
+                "type": "git",
+                "url": "https://github.com/php-http/discovery.git",
+                "reference": "4ff7e1ac2a7fa46eb4390691f02f9b60dd97e1f6"
+            },
+            "dist": {
+                "type": "zip",
+                "url": "https://api.github.com/repos/php-http/discovery/zipball/4ff7e1ac2a7fa46eb4390691f02f9b60dd97e1f6",
+                "reference": "4ff7e1ac2a7fa46eb4390691f02f9b60dd97e1f6",
+                "shasum": ""
+            },
+            "require": {
+                "php": "^5.5 || ^7.0"
+            },
+            "require-dev": {
+                "henrikbjorn/phpspec-code-coverage": "^2.0.2",
+                "php-http/httplug": "^1.0",
+                "php-http/message-factory": "^1.0",
+                "phpspec/phpspec": "^2.4",
+                "puli/composer-plugin": "1.0.0-beta10"
+            },
+            "suggest": {
+                "php-http/message": "Allow to use Guzzle or Diactoros factories",
+                "puli/composer-plugin": "Sets up Puli which is recommended for Discovery to work. Check http://docs.php-http.org/en/latest/discovery.html for more details."
+            },
+            "type": "library",
+            "extra": {
+                "branch-alias": {
+                    "dev-master": "1.0-dev"
+                }
+            },
+            "autoload": {
+                "psr-4": {
+                    "Http\\Discovery\\": "src/"
+                }
+            },
+            "notification-url": "https://packagist.org/downloads/",
+            "license": [
+                "MIT"
+            ],
+            "authors": [
+                {
+                    "name": "Márk Sági-Kazár",
+                    "email": "mark.sagikazar@gmail.com"
+                }
+            ],
+            "description": "Finds installed HTTPlug implementations and PSR-7 message factories",
+            "homepage": "http://php-http.org",
+            "keywords": [
+                "adapter",
+                "client",
+                "discovery",
+                "factory",
+                "http",
+                "message",
+                "psr7"
+            ],
+            "time": "2016-07-18 09:37:58"
         },
         {
             "name": "php-http/guzzle6-adapter",
@@ -446,16 +508,16 @@
         },
         {
             "name": "fabpot/php-cs-fixer",
-            "version": "v1.11.4",
+            "version": "v1.11.5",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "eeb280e909834603ffe03524dbe0066e77c83084"
+                "reference": "d3d08b76753092a232a4d8c3b94095ac06898719"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/eeb280e909834603ffe03524dbe0066e77c83084",
-                "reference": "eeb280e909834603ffe03524dbe0066e77c83084",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/d3d08b76753092a232a4d8c3b94095ac06898719",
+                "reference": "d3d08b76753092a232a4d8c3b94095ac06898719",
                 "shasum": ""
             },
             "require": {
@@ -469,8 +531,12 @@
                 "symfony/process": "~2.3|~3.0",
                 "symfony/stopwatch": "~2.5|~3.0"
             },
+            "conflict": {
+                "hhvm": "<3.9"
+            },
             "require-dev": {
-                "satooshi/php-coveralls": "0.7.*@dev"
+                "phpunit/phpunit": "^4.5|^5",
+                "satooshi/php-coveralls": "^0.7.1"
             },
             "bin": [
                 "php-cs-fixer"
@@ -497,7 +563,7 @@
             ],
             "description": "A tool to automatically fix PHP code style",
             "abandoned": "friendsofphp/php-cs-fixer",
-            "time": "2016-06-07 07:51:27"
+            "time": "2016-07-06 22:49:35"
         },
         {
             "name": "hamcrest/hamcrest-php",
@@ -611,16 +677,16 @@
         },
         {
             "name": "php-http/message",
-            "version": "v1.2.0",
+            "version": "v1.3.1",
             "source": {
                 "type": "git",
                 "url": "https://github.com/php-http/message.git",
-                "reference": "c8fadec9533f5e34a8a730a947fa76363f3aa620"
+                "reference": "6d9c2d682dcf80cb2cc641eebc5693eacee95fa4"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/php-http/message/zipball/c8fadec9533f5e34a8a730a947fa76363f3aa620",
-                "reference": "c8fadec9533f5e34a8a730a947fa76363f3aa620",
+                "url": "https://api.github.com/repos/php-http/message/zipball/6d9c2d682dcf80cb2cc641eebc5693eacee95fa4",
+                "reference": "6d9c2d682dcf80cb2cc641eebc5693eacee95fa4",
                 "shasum": ""
             },
             "require": {
@@ -645,7 +711,7 @@
             "type": "library",
             "extra": {
                 "branch-alias": {
-                    "dev-master": "1.3-dev"
+                    "dev-master": "1.4-dev"
                 }
             },
             "autoload": {
@@ -673,7 +739,7 @@
                 "message",
                 "psr-7"
             ],
-            "time": "2016-03-29 20:44:24"
+            "time": "2016-07-15 14:48:03"
         },
         {
             "name": "php-http/message-factory",
@@ -779,16 +845,16 @@
         },
         {
             "name": "symfony/console",
-            "version": "v3.1.0",
+            "version": "v3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/console.git",
-                "reference": "f62db5b8afec27073a4609b8c84b1f9936652259"
+                "reference": "747154aa69b0f83cd02fc9aa554836dee417631a"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/console/zipball/f62db5b8afec27073a4609b8c84b1f9936652259",
-                "reference": "f62db5b8afec27073a4609b8c84b1f9936652259",
+                "url": "https://api.github.com/repos/symfony/console/zipball/747154aa69b0f83cd02fc9aa554836dee417631a",
+                "reference": "747154aa69b0f83cd02fc9aa554836dee417631a",
                 "shasum": ""
             },
             "require": {
@@ -835,20 +901,20 @@
             ],
             "description": "Symfony Console Component",
             "homepage": "https://symfony.com",
-            "time": "2016-05-30 06:58:39"
+            "time": "2016-06-29 07:02:31"
         },
         {
             "name": "symfony/event-dispatcher",
-            "version": "v3.1.0",
+            "version": "v3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/event-dispatcher.git",
-                "reference": "0343b2cedd0edb26cdc791212a8eb645c406018b"
+                "reference": "7f9839ede2070f53e7e2f0849b9bd14748c434c5"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/0343b2cedd0edb26cdc791212a8eb645c406018b",
-                "reference": "0343b2cedd0edb26cdc791212a8eb645c406018b",
+                "url": "https://api.github.com/repos/symfony/event-dispatcher/zipball/7f9839ede2070f53e7e2f0849b9bd14748c434c5",
+                "reference": "7f9839ede2070f53e7e2f0849b9bd14748c434c5",
                 "shasum": ""
             },
             "require": {
@@ -895,20 +961,20 @@
             ],
             "description": "Symfony EventDispatcher Component",
             "homepage": "https://symfony.com",
-            "time": "2016-04-12 18:27:47"
+            "time": "2016-06-29 05:41:56"
         },
         {
             "name": "symfony/filesystem",
-            "version": "v3.1.0",
+            "version": "v3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/filesystem.git",
-                "reference": "5751e80d6f94b7c018f338a4a7be0b700d6f3058"
+                "reference": "322da5f0910d8aa0b25fa65ffccaba68dbddb890"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/filesystem/zipball/5751e80d6f94b7c018f338a4a7be0b700d6f3058",
-                "reference": "5751e80d6f94b7c018f338a4a7be0b700d6f3058",
+                "url": "https://api.github.com/repos/symfony/filesystem/zipball/322da5f0910d8aa0b25fa65ffccaba68dbddb890",
+                "reference": "322da5f0910d8aa0b25fa65ffccaba68dbddb890",
                 "shasum": ""
             },
             "require": {
@@ -944,20 +1010,20 @@
             ],
             "description": "Symfony Filesystem Component",
             "homepage": "https://symfony.com",
-            "time": "2016-04-12 18:27:47"
+            "time": "2016-06-29 05:41:56"
         },
         {
             "name": "symfony/finder",
-            "version": "v3.1.0",
+            "version": "v3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/finder.git",
-                "reference": "40d17ed287bf51a2f884c4619ce8ff2a1c5cd219"
+                "reference": "8201978de88a9fa0923e18601bb17f1df9c721e7"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/finder/zipball/40d17ed287bf51a2f884c4619ce8ff2a1c5cd219",
-                "reference": "40d17ed287bf51a2f884c4619ce8ff2a1c5cd219",
+                "url": "https://api.github.com/repos/symfony/finder/zipball/8201978de88a9fa0923e18601bb17f1df9c721e7",
+                "reference": "8201978de88a9fa0923e18601bb17f1df9c721e7",
                 "shasum": ""
             },
             "require": {
@@ -993,7 +1059,7 @@
             ],
             "description": "Symfony Finder Component",
             "homepage": "https://symfony.com",
-            "time": "2016-05-13 18:06:41"
+            "time": "2016-06-29 05:41:56"
         },
         {
             "name": "symfony/polyfill-mbstring",
@@ -1056,16 +1122,16 @@
         },
         {
             "name": "symfony/process",
-            "version": "v3.1.0",
+            "version": "v3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/process.git",
-                "reference": "1574f3451b40fa9bbae518ef71d19a56f409cac0"
+                "reference": "5c11a1a4d4016662eeaf0f8757958c7de069f9a0"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/process/zipball/1574f3451b40fa9bbae518ef71d19a56f409cac0",
-                "reference": "1574f3451b40fa9bbae518ef71d19a56f409cac0",
+                "url": "https://api.github.com/repos/symfony/process/zipball/5c11a1a4d4016662eeaf0f8757958c7de069f9a0",
+                "reference": "5c11a1a4d4016662eeaf0f8757958c7de069f9a0",
                 "shasum": ""
             },
             "require": {
@@ -1101,20 +1167,20 @@
             ],
             "description": "Symfony Process Component",
             "homepage": "https://symfony.com",
-            "time": "2016-04-12 19:11:33"
+            "time": "2016-06-29 05:42:25"
         },
         {
             "name": "symfony/stopwatch",
-            "version": "v3.1.0",
+            "version": "v3.1.2",
             "source": {
                 "type": "git",
                 "url": "https://github.com/symfony/stopwatch.git",
-                "reference": "4670f122fa32a4900003a6802f6b8575f3f0b17e"
+                "reference": "bb42806b12c5f89db4ebf64af6741afe6d8457e1"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/4670f122fa32a4900003a6802f6b8575f3f0b17e",
-                "reference": "4670f122fa32a4900003a6802f6b8575f3f0b17e",
+                "url": "https://api.github.com/repos/symfony/stopwatch/zipball/bb42806b12c5f89db4ebf64af6741afe6d8457e1",
+                "reference": "bb42806b12c5f89db4ebf64af6741afe6d8457e1",
                 "shasum": ""
             },
             "require": {
@@ -1150,7 +1216,7 @@
             ],
             "description": "Symfony Stopwatch Component",
             "homepage": "https://symfony.com",
-            "time": "2016-03-04 07:56:56"
+            "time": "2016-06-29 05:41:56"
         }
     ],
     "aliases": [],
@@ -1159,7 +1225,7 @@
     "prefer-stable": false,
     "prefer-lowest": false,
     "platform": {
-        "php": ">=5.5.0"
+        "php": "^5.5 || ^7.0"
     },
     "platform-dev": []
 }

--- a/composer.lock
+++ b/composer.lock
@@ -508,16 +508,16 @@
         },
         {
             "name": "fabpot/php-cs-fixer",
-            "version": "v1.11.5",
+            "version": "v1.11.6",
             "source": {
                 "type": "git",
                 "url": "https://github.com/FriendsOfPHP/PHP-CS-Fixer.git",
-                "reference": "d3d08b76753092a232a4d8c3b94095ac06898719"
+                "reference": "41dc93abd2937a85a3889e28765231d574d2bac8"
             },
             "dist": {
                 "type": "zip",
-                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/d3d08b76753092a232a4d8c3b94095ac06898719",
-                "reference": "d3d08b76753092a232a4d8c3b94095ac06898719",
+                "url": "https://api.github.com/repos/FriendsOfPHP/PHP-CS-Fixer/zipball/41dc93abd2937a85a3889e28765231d574d2bac8",
+                "reference": "41dc93abd2937a85a3889e28765231d574d2bac8",
                 "shasum": ""
             },
             "require": {
@@ -563,7 +563,7 @@
             ],
             "description": "A tool to automatically fix PHP code style",
             "abandoned": "friendsofphp/php-cs-fixer",
-            "time": "2016-07-06 22:49:35"
+            "time": "2016-07-22 06:46:28"
         },
         {
             "name": "hamcrest/hamcrest-php",

--- a/composer.lock
+++ b/composer.lock
@@ -4,8 +4,8 @@
         "Read more about it at https://getcomposer.org/doc/01-basic-usage.md#composer-lock-the-lock-file",
         "This file is @generated automatically"
     ],
-    "hash": "f3aa73ae7dde80f1176649ef01f86204",
-    "content-hash": "5714a77e64c935d51c3630dfc84eeb1b",
+    "hash": "3819276e6b3cfa8402d49ebf6368c31f",
+    "content-hash": "b6a4b7fc0e641a174474821e49ef3070",
     "packages": [
         {
             "name": "guzzlehttp/guzzle",

--- a/test/unit/SparkPostTest.php
+++ b/test/unit/SparkPostTest.php
@@ -58,12 +58,12 @@ class SparkPostTest extends \PHPUnit_Framework_TestCase
     {
         $responseMock = Mockery::mock('Psr\Http\Message\ResponseInterface');
         $this->resource->setOptions(['async' => false]);
-        $this->resource->httpClient->shouldReceive('sendRequest')->andReturn($responseMock);
+        $this->clientMock->shouldReceive('sendRequest')->andReturn($responseMock);
         $this->assertInstanceOf('SparkPost\SparkPostResponse', $this->resource->request('POST', 'transmissions', $this->postTransmissionPayload));
 
         $promiseMock = Mockery::mock('Http\Promise\Promise');
         $this->resource->setOptions(['async' => true]);
-        $this->resource->httpClient->shouldReceive('sendAsyncRequest')->andReturn($promiseMock);
+        $this->clientMock->shouldReceive('sendAsyncRequest')->andReturn($promiseMock);
         $this->assertInstanceOf('SparkPost\SparkPostPromise', $this->resource->request('GET', 'transmissions', $this->getTransmissionPayload));
     }
 
@@ -74,7 +74,7 @@ class SparkPostTest extends \PHPUnit_Framework_TestCase
 
         $responseBody = ['results' => 'yay'];
 
-        $this->resource->httpClient->shouldReceive('sendRequest')->
+        $this->clientMock->shouldReceive('sendRequest')->
             once()->
             with(Mockery::type('GuzzleHttp\Psr7\Request'))->
             andReturn($responseMock);
@@ -95,7 +95,7 @@ class SparkPostTest extends \PHPUnit_Framework_TestCase
 
         $responseBody = ['results' => 'failed'];
 
-        $this->resource->httpClient->shouldReceive('sendRequest')->
+        $this->clientMock->shouldReceive('sendRequest')->
             once()->
             with(Mockery::type('GuzzleHttp\Psr7\Request'))->
             andThrow($exceptionMock);
@@ -119,7 +119,7 @@ class SparkPostTest extends \PHPUnit_Framework_TestCase
 
         $responseBody = ['results' => 'yay'];
 
-        $this->resource->httpClient->shouldReceive('sendAsyncRequest')->
+        $this->clientMock->shouldReceive('sendAsyncRequest')->
             once()->
             with(Mockery::type('GuzzleHttp\Psr7\Request'))->
             andReturn($promiseMock);
@@ -145,7 +145,7 @@ class SparkPostTest extends \PHPUnit_Framework_TestCase
 
         $responseBody = ['results' => 'failed'];
 
-        $this->resource->httpClient->shouldReceive('sendAsyncRequest')->
+        $this->clientMock->shouldReceive('sendAsyncRequest')->
             once()->
             with(Mockery::type('GuzzleHttp\Psr7\Request'))->
             andReturn($promiseMock);
@@ -205,7 +205,7 @@ class SparkPostTest extends \PHPUnit_Framework_TestCase
     {
         $promiseMock = Mockery::mock('Http\Promise\Promise');
 
-        $this->resource->httpClient->shouldReceive('sendAsyncRequest')->
+        $this->clientMock->shouldReceive('sendAsyncRequest')->
             once()->
             with(Mockery::type('GuzzleHttp\Psr7\Request'))->
             andReturn($promiseMock);

--- a/test/unit/SparkPostTest.php
+++ b/test/unit/SparkPostTest.php
@@ -2,6 +2,9 @@
 
 namespace SparkPost\Test;
 
+use Http\Client\HttpAsyncClient;
+use Http\Client\HttpClient;
+use Http\Message\MessageFactory;
 use SparkPost\SparkPost;
 use SparkPost\SparkPostPromise;
 use GuzzleHttp\Promise\FulfilledPromise as GuzzleFulfilledPromise;
@@ -12,6 +15,7 @@ use SparkPost\Test\TestUtils\ClassUtils;
 
 class SparkPostTest extends \PHPUnit_Framework_TestCase
 {
+    /** @var ClassUtils */
     private static $utils;
     private $clientMock;
     /** @var SparkPost */
@@ -220,7 +224,7 @@ class SparkPostTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Exception
      */
     public function testUnsupportedAsyncRequest()
     {
@@ -252,8 +256,24 @@ class SparkPostTest extends \PHPUnit_Framework_TestCase
 
     public function testSetHttpClient()
     {
-        $this->resource->setHttpClient($this->clientMock);
-        $this->assertEquals($this->clientMock, self::$utils->getProperty($this->resource, 'httpClient'));
+        $mock = Mockery::mock(HttpClient::class);
+        $this->resource->setHttpClient($mock);
+        $this->assertEquals($mock, self::$utils->getProperty($this->resource, 'httpClient'));
+    }
+
+    public function testSetHttpAsyncClient()
+    {
+        $mock = Mockery::mock(HttpAsyncClient::class);
+        $this->resource->setHttpClient($mock);
+        $this->assertEquals($mock, self::$utils->getProperty($this->resource, 'httpClient'));
+    }
+
+    /**
+     * @expectedException \Exception
+     */
+    public function testSetHttpClientException()
+    {
+        $this->resource->setHttpClient(new \stdClass());
     }
 
     public function testSetOptionsStringKey()
@@ -264,11 +284,19 @@ class SparkPostTest extends \PHPUnit_Framework_TestCase
     }
 
     /**
-     * @expectedException Exception
+     * @expectedException \Exception
      */
     public function testSetBadOptions()
     {
         self::$utils->setProperty($this->resource, 'options', []);
         $this->resource->setOptions(['not' => 'SPARKPOST_API_KEY']);
+    }
+
+    public function testSetMessageFactory()
+    {
+        $messageFactory = Mockery::mock(MessageFactory::class);
+        $this->resource->setMessageFactory($messageFactory);
+
+        $this->assertEquals($messageFactory, self::$utils->getMethod('getMessageFactory')->invoke($this->resource));
     }
 }

--- a/test/unit/TestUtils/ClassUtils.php
+++ b/test/unit/TestUtils/ClassUtils.php
@@ -18,9 +18,9 @@ class ClassUtils
      *
      * @param string $name
      *
-     * @return ReflectionMethod
+     * @return \ReflectionMethod
      */
-    public function getMethod($method)
+    public function getMethod($name)
     {
         $method = $this->class->getMethod($name);
         $method->setAccessible(true);
@@ -33,10 +33,10 @@ class ClassUtils
      *
      * This is needed to mock the GuzzleHttp\Client responses
      *
-     * @param string $name
-     * @param {*}
+     * @param object $instance
+     * @param string $property
      *
-     * @return ReflectionMethod
+     * @return mixed
      */
     public function getProperty($instance, $property)
     {
@@ -50,10 +50,10 @@ class ClassUtils
      *
      * This is needed to mock the GuzzleHttp\Client responses
      *
-     * @param string $name
-     * @param {*}
      *
-     * @return ReflectionMethod
+     * @param object $instance
+     * @param string $property
+     * @param mixed $value
      */
     public function setProperty($instance, $property, $value)
     {

--- a/test/unit/TransmissionTest.php
+++ b/test/unit/TransmissionTest.php
@@ -86,7 +86,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
 
         $responseBody = ['results' => 'yay'];
 
-        $this->resource->httpClient->shouldReceive('sendRequest')->
+        $this->clientMock->shouldReceive('sendRequest')->
             once()->
             with(Mockery::type('GuzzleHttp\Psr7\Request'))->
             andReturn($responseMock);
@@ -108,7 +108,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
 
         $responseBody = ['results' => 'yay'];
 
-        $this->resource->httpClient->shouldReceive('sendRequest')->
+        $this->clientMock->shouldReceive('sendRequest')->
             once()->
             with(Mockery::type('GuzzleHttp\Psr7\Request'))->
             andReturn($responseMock);
@@ -130,7 +130,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
 
         $responseBody = ['results' => 'yay'];
 
-        $this->resource->httpClient->shouldReceive('sendRequest')->
+        $this->clientMock->shouldReceive('sendRequest')->
             once()->
             with(Mockery::type('GuzzleHttp\Psr7\Request'))->
             andReturn($responseMock);
@@ -152,7 +152,7 @@ class TransmissionTest extends \PHPUnit_Framework_TestCase
 
         $responseBody = ['results' => 'yay'];
 
-        $this->resource->httpClient->shouldReceive('sendRequest')->
+        $this->clientMock->shouldReceive('sendRequest')->
             once()->
             with(Mockery::type('GuzzleHttp\Psr7\Request'))->
             andReturn($responseMock);


### PR DESCRIPTION
Removed dependency from Guzzle. If we use php-http/discovery instead of guzzlehttp/psr7 we can let the user decide what implementation to use. 

I also did some code cleanup and make sure someone can add a async client. 