### PR TITLE
Setters should return current object.

### DIFF
--- a/lib/SparkPost/SparkPost.php
+++ b/lib/SparkPost/SparkPost.php
@@ -208,6 +208,8 @@ class SparkPost
      * Sets $httpClient to be used for request.
      *
      * @param HttpClient|HttpAsyncClient $httpClient - the client to be used for request
+     *
+     * @return SparkPost
      */
     public function setHttpClient($httpClient)
     {
@@ -216,12 +218,16 @@ class SparkPost
         }
 
         $this->httpClient = $httpClient;
+        
+        return $this;
     }
 
     /**
      * Sets the options from the param and defaults for the SparkPost object.
      *
      * @param array $options - either an string API key or an array of options
+     *
+     * @return SparkPost
      */
     public function setOptions($options)
     {
@@ -243,6 +249,8 @@ class SparkPost
                 $this->options[$option] = $value;
             }
         }
+        
+        return $this;
     }
 
     /**


### PR DESCRIPTION
We should return current object from all setters to make them compatible with [fluent interface](https://en.wikipedia.org/wiki/Fluent_interface) (allow chaining).
