### PR TITLE
Issue-168: Optional automatic retry on 5xx

### DIFF
--- a/README.md
+++ b/README.md
@@ -102,6 +102,11 @@ $sparky = new SparkPost($httpClient, ['key'=>'YOUR_API_KEY']);
     * Type: `Boolean`
     * Default: `true`
     * `async` defines if the `request` function sends an asynchronous or synchronous request. If your client does not support async requests set this to `false`
+* `options.retries`
+    * Required: No
+    * Type: `Number`
+    * Default: `0`
+    * `retries` controls how many API call attempts the client makes after receiving a 5xx response
 * `options.debug`
     * Required: No
     * Type: `Boolean`

--- a/examples/message-events/get_message_events_with_retry_logic.php
+++ b/examples/message-events/get_message_events_with_retry_logic.php
@@ -1,0 +1,33 @@
+<?php
+
+namespace Examples\Templates;
+
+require dirname(__FILE__).'/../bootstrap.php';
+
+use SparkPost\SparkPost;
+use GuzzleHttp\Client;
+use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
+
+$httpClient = new GuzzleAdapter(new Client());
+
+$sparky = new SparkPost($httpClient, ["key" => "YOUR_API_KEY", "retries" => 3]);
+
+$promise = $sparky->request('GET', 'message-events', [
+    'campaign_ids' => 'CAMPAIGN_ID',
+]);
+
+/**
+ * If this fails with a 5xx it will have failed 4 times
+ */
+try {
+    $response = $promise->wait();
+    echo $response->getStatusCode()."\n";
+    print_r($response->getBody())."\n";
+} catch (\Exception $e) {
+    echo $e->getCode()."\n";
+    echo $e->getMessage()."\n";
+
+    if ($e->getCode() >= 500 && $e->getCode() <= 599) {
+        echo "Wow, this failed epically";
+    }
+}

--- a/lib/SparkPost/SparkPost.php
+++ b/lib/SparkPost/SparkPost.php
@@ -41,6 +41,7 @@ class SparkPost
         'version' => 'v1',
         'async' => true,
         'debug' => false,
+        'retries' => 0
     ];
 
     /**
@@ -97,11 +98,27 @@ class SparkPost
         $requestValues = $this->buildRequestValues($method, $uri, $payload, $headers);
         $request = call_user_func_array(array($this, 'buildRequestInstance'), $requestValues);
 
+        $retries = $this->options['retries'];
         try {
-            return new SparkPostResponse($this->httpClient->sendRequest($request), $this->ifDebug($requestValues));
+            if ($retries > 0) {
+              $resp = $this->syncReqWithRetry($request, $retries);
+            } else {
+              $resp = $this->httpClient->sendRequest($request);
+            }
+            return new SparkPostResponse($resp, $this->ifDebug($requestValues));
         } catch (\Exception $exception) {
             throw new SparkPostException($exception, $this->ifDebug($requestValues));
         }
+    }
+
+    private function syncReqWithRetry($request, $retries)
+    {
+        $resp = $this->httpClient->sendRequest($request);
+        $status = $resp->getStatusCode();
+        if ($status >= 500 && $status <= 599 && $retries > 0) {
+          return $this->syncReqWithRetry($request, $retries-1);
+        }
+        return $resp;
     }
 
     /**
@@ -120,10 +137,26 @@ class SparkPost
             $requestValues = $this->buildRequestValues($method, $uri, $payload, $headers);
             $request = call_user_func_array(array($this, 'buildRequestInstance'), $requestValues);
 
-            return new SparkPostPromise($this->httpClient->sendAsyncRequest($request), $this->ifDebug($requestValues));
+            $retries = $this->options['retries'];
+            if ($retries > 0) {
+                return new SparkPostPromise($this->asyncReqWithRetry($request, $retries), $this->ifDebug($requestValues));
+            } else {
+                return new SparkPostPromise($this->httpClient->sendAsyncRequest($request), $this->ifDebug($requestValues));
+            }
         } else {
             throw new \Exception('Your http client does not support asynchronous requests. Please use a different client or use synchronous requests.');
         }
+    }
+
+    private function asyncReqWithRetry($request, $retries)
+    {
+        return $this->httpClient->sendAsyncRequest($request)->then(function($response) use ($request, $retries) {
+            $status = $response->getStatusCode();
+            if ($status >= 500 && $status <= 599 && $retries > 0) {
+                return $this->asyncReqWithRetry($request, $retries-1);
+            }
+            return $response;
+        });
     }
 
     /**
@@ -252,7 +285,7 @@ class SparkPost
         }
 
         $this->httpClient = $httpClient;
-        
+
         return $this;
     }
 
@@ -283,7 +316,7 @@ class SparkPost
                 $this->options[$option] = $value;
             }
         }
-        
+
         return $this;
     }
 


### PR DESCRIPTION
Addresses #168:
 - Added a `retries` option to control API call retry count
 - By default, no retries are attempted to protect existing tested code paths and compatibility
 - When enabled, each request will be retried until it returns non 5xx status or `retries` attempts are reached.