### PR TITLE
Make promises usage more explicit

### DIFF
--- a/README.md
+++ b/README.md
@@ -298,6 +298,9 @@ $promise->then(
 );
 
 echo "I will print out before the promise is fulfilled";
+
+// You can combine multiple promises using \GuzzleHttp\Promise\all() and other functions from the library.
+$promise->wait();
 ```
 
 ## Handling Exceptions


### PR DESCRIPTION
Current async example makes assumption that the promise will be resolved somewhere in the code later, but for newbies to this concept it's not clear.