### PR TITLE
Ties php-http/guzzle6-adapter to pre-PHP raise version

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8 || ^5.4",
-    "php-http/guzzle6-adapter": "master#54181ff8455a4c2e1706a53e0d98060b93030321",
+    "php-http/guzzle6-adapter": "1.1.1",
     "mockery/mockery": "^0.9.4",
     "friendsofphp/php-cs-fixer": "^1.11",
     "nyholm/nsa": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8 || ^5.4",
-    "php-http/guzzle6-adapter": "^1.0",
+    "php-http/guzzle6-adapter": "dev-master#54181ff8455a4c2e1706a53e0d98060b93030321",
     "mockery/mockery": "^0.9.4",
     "friendsofphp/php-cs-fixer": "^1.11",
     "nyholm/nsa": "^1.0",

--- a/composer.json
+++ b/composer.json
@@ -21,7 +21,7 @@
   },
   "require-dev": {
     "phpunit/phpunit": "^4.8 || ^5.4",
-    "php-http/guzzle6-adapter": "dev-master#54181ff8455a4c2e1706a53e0d98060b93030321",
+    "php-http/guzzle6-adapter": "master#54181ff8455a4c2e1706a53e0d98060b93030321",
     "mockery/mockery": "^0.9.4",
     "friendsofphp/php-cs-fixer": "^1.11",
     "nyholm/nsa": "^1.0",


### PR DESCRIPTION
Per [#182](https://github.com/SparkPost/php-sparkpost/issues/182), the php-http/guzzle6-adapter library, after not being updated for over a year decided to suddenly increase the PHP version requirements from 5.5 to 7.1 without issuing a new version (much less a new major release). This has caused existing composer checkouts to break if updating, and new ones to not work correctly on the affected PHP versions, which are supposed by this library.

This PR ties the composer requirements to the commit before the version increase, allowing for the fix of this issue.