### PR TITLE
Address #197: No longer need formfeed replacement. README work.

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,11 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [2.2.1] - 2021-03-08
+
+- [#198](https://github.com/SparkPost/php-sparkpost/pull/198)
+- [#191](https://github.com/SparkPost/php-sparkpost/pull/191)
+
 ## [2.2.0] - 2019-06-04
 - [#187](https://github.com/SparkPost/php-sparkpost/pull/169) Updated composer.json
 - [#169](https://github.com/SparkPost/php-sparkpost/pull/169) Optional automatic retry on 5xx
@@ -103,7 +108,8 @@ This major release included a complete refactor of the library to be a thin HTTP
 ### Fixed
 - README now has proper code blocks denoting PHP language
 
-[unreleased]: https://github.com/sparkpost/php-sparkpost/compare/2.2.0...HEAD
+[unreleased]: https://github.com/sparkpost/php-sparkpost/compare/2.2.1...HEAD
+[2.2.1]: https://github.com/sparkpost/php-sparkpost/compare/2.2.0...2.2.1
 [2.2.0]: https://github.com/sparkpost/php-sparkpost/compare/2.1.0...2.2.0
 [2.1.0]: https://github.com/sparkpost/php-sparkpost/compare/2.0.3...2.1.0
 [2.0.3]: https://github.com/sparkpost/php-sparkpost/compare/2.0.2...2.0.3

--- a/README.md
+++ b/README.md
@@ -56,6 +56,17 @@ Http\Discovery\Exception\PuliUnavailableException: Puli Factory is not available
 
 [This is usual](http://docs.php-http.org/en/latest/discovery.html#puli-factory-is-not-available). Puli is not required to use the library. You can resume running after the exception.
 
+You can prevent the exception, by setting the discovery strategies, prior to creating the adapter object:
+```php
+// Prevent annoying "Puli exception" during work with xdebug / IDE
+// See https://github.com/getsentry/sentry-php/issues/801
+\Http\Discovery\ClassDiscovery::setStrategies([
+        // \Http\Discovery\Strategy\PuliBetaStrategy::class, // Deliberately disabled
+        \Http\Discovery\Strategy\CommonClassesStrategy::class,
+        \Http\Discovery\Strategy\CommonPsr17ClassesStrategy::class,
+]);
+```
+
 ## Setting up a Request Adapter
 
 Because of dependency collision, we have opted to use a request adapter rather than

--- a/lib/SparkPost/SparkPost.php
+++ b/lib/SparkPost/SparkPost.php
@@ -184,12 +184,8 @@ class SparkPost
         $url = $this->getUrl($uri, $params);
         $headers = $this->getHttpHeaders($headers);
 
-        // Sparkpost API will not tolerate form feed in JSON.
-        $jsonReplace = [
-            '\f' => '',
-        ];
-        $body = strtr(json_encode($body), $jsonReplace);
-
+        // old form-feed workaround now removed
+        $body = json_encode($body);
         return [
             'method' => $method,
             'url' => $url,


### PR DESCRIPTION
Removed the formfeed replacement code. Confirmed that the error reported in #197 is no longer seen, and that the email is sent as expected.

Updated the main README example (as it was broken). Needs the async option setting to make it work. Added try { } clause as good practice, and made it print out the response results too.

I also added some //TODO comments next to the transmissions->get call that will not work.