### PR TITLE
Update examples

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -7,3 +7,9 @@ test/output/
 /composer.phar
 composer.lock
 test.php
+.php-version
+.gitignore
+.phpunit.result.cache
+.DS_Store
+.gitignore
+.vscode/launch.json

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,13 +4,14 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
-## [2.2.1] - 2021-03-08
+- [#200](https://github.com/SparkPost/php-sparkpost/pull/200) PHP 8 support
 
-- [#198](https://github.com/SparkPost/php-sparkpost/pull/198)
-- [#191](https://github.com/SparkPost/php-sparkpost/pull/191)
+## [2.2.1] - 2021-03-08
+- [#198](https://github.com/SparkPost/php-sparkpost/pull/198) Address #197: No longer need formfeed replacement. README work.
+- [#191](https://github.com/SparkPost/php-sparkpost/pull/191) Updating License
 
 ## [2.2.0] - 2019-06-04
-- [#187](https://github.com/SparkPost/php-sparkpost/pull/169) Updated composer.json
+- [#187](https://github.com/SparkPost/php-sparkpost/pull/187) Updated composer.json
 - [#169](https://github.com/SparkPost/php-sparkpost/pull/169) Optional automatic retry on 5xx
 - [#166](https://github.com/SparkPost/php-sparkpost/pull/166/files) Quick fix for using the API without composer
 - [#149](https://github.com/SparkPost/php-sparkpost/pull/149) Setters should return current object

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,7 +5,7 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 ## [Unreleased][unreleased]
 
 ## [2.3.0] - 2021-03-16
-- [#201](https://github.com/SparkPost/php-sparkpost/pull/200) Update examples, README
+- [#201](https://github.com/SparkPost/php-sparkpost/pull/201) Update examples, README
 - [#200](https://github.com/SparkPost/php-sparkpost/pull/200) PHP 8 support
 
 ## [2.2.1] - 2021-03-08

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,8 @@ This project adheres to [Semantic Versioning](http://semver.org/).
 
 ## [Unreleased][unreleased]
 
+## [2.3.0] - 2021-03-16
+- [#201](https://github.com/SparkPost/php-sparkpost/pull/200) Update examples, README
 - [#200](https://github.com/SparkPost/php-sparkpost/pull/200) PHP 8 support
 
 ## [2.2.1] - 2021-03-08

--- a/CONTRIBUTING.md
+++ b/CONTRIBUTING.md
@@ -24,11 +24,41 @@ curl -sS https://getcomposer.org/installer | php
 
 Add composer install directory to $PATH `~/.composer/vendor/bin/`
 
-#### Install PHPUnit for Testing
-```
-composer global require "phpunit/phpunit=4.8.*"
+### phpenv
+
+[phpenv](https://github.com/phpenv/phpenv-installer) is useful for testing locally across different PHP versions.
+
+### Developing your app against a local version of the SparkPost library
+
+If you're working on the library and your app together, you can tell Composer to get `php-sparkpost` from a local path. With a directory structure such as:
+
+home
+ - php-sparkpost
+ - my-app
+    - composer.json
+    - .. etc
+
+Use the following for `my-app/composer.json`:
+```json
+{
+    "name": "sparkpost/php_simple_email_send",
+    "description": "a small test program to send an email",
+    "repositories": [
+        {
+            "type": "path",
+            "url": "../php-sparkpost"
+        }
+    ],
+    "require": {
+        "php-http/guzzle6-adapter": "^1.1",
+        "guzzlehttp/guzzle": "^6.0",
+        "sparkpost/sparkpost": "dev-master"
+    }
+}
 ```
 
+
+### Memory
 We recommend increasing PHP’s memory limit, by default it uses 128MB.  We ran into some issues during local development without doing so.  You can do this by editing your php.ini file and modifying `memory_limit`.  We set ours to `memory_limit = 1024M`.
 
 #### Install XDebug for code coverage generation
@@ -68,6 +98,7 @@ Once you are setup for local development:
 
 ## Releasing
 
-* Update version information in composer.json during development.
-* Once its been merged down, create a release tag in git.
+* Update version in the [library](https://github.com/SparkPost/php-sparkpost/blob/eeb6ba971584fcc4c12fd69247c6b24df7827af5/lib/SparkPost/SparkPost.php#L16) during development. This is used in the `user_agent` of your requests.
+
+* Once it's been merged down, create a release tag in git.
 * Composer will automatically pickup the new tag and present it as a release.

--- a/README.md
+++ b/README.md
@@ -249,7 +249,7 @@ var_dump($results);
 ```
 
 More examples [here](./examples/):
-### Transmission
+### [Transmissions](./examples/transmissions/)
 - Create with attachment
 - Create with recipient list
 - Create with cc and bcc
@@ -257,14 +257,14 @@ More examples [here](./examples/):
 - Create
 - Delete (scheduled transmission by campaign_id *only*)
 
-### Template
+### [Templates](./examples/templates/)
 - Create
 - Get
 - Get (list) all
 - Update
 - Delete
 
-### Message Events
+### [Message Events](./examples/message-events/)
 - get
 - get (with retry logic)
 

--- a/README.md
+++ b/README.md
@@ -170,12 +170,9 @@ Sends an asynchronous request to the SparkPost API and returns a `SparkPostPromi
     *  Type: `Array`
     * See constructor
 
-
+---
 ## Endpoints
 ### transmissions
-* **get([transmissionID] [, payload])**
-    * `transmissionID` - see `uri` request options
-    * `payload` - see request options
 * **post(payload)**
     * `payload` - see request options
     * `payload.cc`
@@ -186,8 +183,8 @@ Sends an asynchronous request to the SparkPost API and returns a `SparkPostPromi
         * Required: No
         * Type: `Array`
         * Recipients to descreetly recieve a carbon copy of the transmission
-* **delete(transmissionID)**
-    * `transmissionID` - see `uri` request options
+
+For complete list of endpoints, refer to [API documentation](https://developers.sparkpost.com/api/).
 
 ## Examples
 
@@ -252,6 +249,26 @@ var_dump($results);
 ?>
 ```
 
+More examples [here](./examples/):
+### Transmission
+- Create with attachment
+- Create with recipient list
+- Create with cc and bcc
+- Create with template
+- Create
+- Delete (scheduled transmission by campaign_id *only*)
+
+### Template
+- Create
+- Get
+- Get (list) all
+- Update
+- Delete
+
+### Message Events
+- get
+- get (with retry logic)
+
 ### Send An API Call Using The Base Request Function
 We provide a base request function to access any of our API resources.
 ```php
@@ -273,7 +290,6 @@ $promise = $sparky->request('GET', 'metrics/ip-pools', [
 ]);
 ?>
 ```
-
 
 ## Handling Responses
 The API calls either return a `SparkPostPromise` or `SparkPostResponse` depending on if `async` is `true` or `false`

--- a/README.md
+++ b/README.md
@@ -298,7 +298,7 @@ The API calls either return a `SparkPostPromise` or `SparkPostResponse` dependin
 ```php
 $sparky->setOptions(['async' => false]);
 try {
-    $response = $sparky->transmissions->get();
+    $response = ... // YOUR API CALL GOES HERE
 
     echo $response->getStatusCode()."\n";
     print_r($response->getBody())."\n";
@@ -314,7 +314,7 @@ Asynchronous an be handled in two ways: by passing callbacks or waiting for the 
 ##### Wait (Synchronous)
 ```php
 
-$promise = // YOUR API CALL GOES HERE
+$promise = ... // YOUR API CALL GOES HERE
 
 try {
     $response = $promise->wait();
@@ -330,7 +330,7 @@ echo "I will print out after the promise is fulfilled";
 
 ##### Then (Asynchronous)
 ```php
-$promise = // YOUR API CALL GOES HERE
+$promise = ... // YOUR API CALL GOES HERE
 
 $promise->then(
     // Success callback

--- a/README.md
+++ b/README.md
@@ -183,8 +183,6 @@ Sends an asynchronous request to the SparkPost API and returns a `SparkPostPromi
         * Type: `Array`
         * Recipients to descreetly recieve a carbon copy of the transmission
 
-For complete list of endpoints, refer to [API documentation](https://developers.sparkpost.com/api/).
-
 ## Examples
 
 ### Send An Email Using The Transmissions Endpoint
@@ -269,6 +267,7 @@ More examples [here](./examples/):
 - get (with retry logic)
 
 ### Send An API Call Using The Base Request Function
+
 We provide a base request function to access any of our API resources.
 ```php
 <?php
@@ -279,16 +278,19 @@ use GuzzleHttp\Client;
 use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 
 $httpClient = new GuzzleAdapter(new Client());
-$sparky = new SparkPost($httpClient, ['key'=>'YOUR_API_KEY']);
+$sparky = new SparkPost($httpClient, [
+    'key' => getenv('SPARKPOST_API_KEY'),
+    'async' => false]);
 
-$promise = $sparky->request('GET', 'metrics/ip-pools', [
-    'from' => '2014-12-01T09:00',
-    'to' => '2015-12-01T08:00',
-    'timezone' => 'America/New_York',
-    'limit' => '5',
-]);
+$webhookId = 'afd20f50-865a-11eb-ac38-6d7965d56459';
+$response = $sparky->request('DELETE', 'webhooks/' . $webhookId);
+print($response->getStatusCode());
 ?>
 ```
+
+> Be sure to not have a leading `/` in your resource URI.
+
+For complete list of resources, refer to [API documentation](https://developers.sparkpost.com/api/).
 
 ## Handling Responses
 The API calls either return a `SparkPostPromise` or `SparkPostResponse` depending on if `async` is `true` or `false`

--- a/README.md
+++ b/README.md
@@ -170,7 +170,6 @@ Sends an asynchronous request to the SparkPost API and returns a `SparkPostPromi
     *  Type: `Array`
     * See constructor
 
----
 ## Endpoints
 ### transmissions
 * **post(payload)**

--- a/README.md
+++ b/README.md
@@ -143,7 +143,7 @@ $sparky = new SparkPost($httpClient, ['key'=>'YOUR_API_KEY']);
 * `uri`
     * Required: Yes
     * Type: `String`
-    * The URI to recieve the request
+    * The URI to receive the request
 * `payload`
     * Required: No
     * Type: `Array`
@@ -177,11 +177,11 @@ Sends an asynchronous request to the SparkPost API and returns a `SparkPostPromi
     * `payload.cc`
         * Required: No
         * Type: `Array`
-        * Recipients to recieve a carbon copy of the transmission
+        * Recipients to receive a carbon copy of the transmission
     * `payload.bcc`
         * Required: No
         * Type: `Array`
-        * Recipients to descreetly recieve a carbon copy of the transmission
+        * Recipients to discreetly receive a carbon copy of the transmission
 
 ## Examples
 
@@ -196,9 +196,8 @@ use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 
 $httpClient = new GuzzleAdapter(new Client());
 // Good practice to not have API key literals in code - set an environment variable instead
-$sparky = new SparkPost($httpClient, ['key' => getenv('SPARKPOST_API_KEY')]);
 // For simple example, use synchronous model
-$sparky->setOptions(['async' => false]);
+$sparky = new SparkPost($httpClient, ['key' => getenv('SPARKPOST_API_KEY'), 'async' => false]);
 
 try {
     $response = $sparky->transmissions->post([
@@ -299,7 +298,7 @@ The API calls either return a `SparkPostPromise` or `SparkPostResponse` dependin
 ```php
 $sparky->setOptions(['async' => false]);
 try {
-    $response = $sparky->transmissions->get(); //TODO: Change this. Transmissions no longer supports GET call
+    $response = $sparky->transmissions->get();
 
     echo $response->getStatusCode()."\n";
     print_r($response->getBody())."\n";
@@ -314,7 +313,8 @@ catch (\Exception $e) {
 Asynchronous an be handled in two ways: by passing callbacks or waiting for the promise to be fulfilled. Waiting acts like synchronous request.
 ##### Wait (Synchronous)
 ```php
-$promise = $sparky->transmissions->get(); //TODO: Change this. Transmissions no longer supports GET call
+
+$promise = // YOUR API CALL GOES HERE
 
 try {
     $response = $promise->wait();
@@ -330,7 +330,7 @@ echo "I will print out after the promise is fulfilled";
 
 ##### Then (Asynchronous)
 ```php
-$promise = $sparky->transmissions->get(); //TODO: Change this. Transmissions no longer supports GET call
+$promise = // YOUR API CALL GOES HERE
 
 $promise->then(
     // Success callback

--- a/examples/debug/index.php
+++ b/examples/debug/index.php
@@ -14,8 +14,8 @@ $httpClient = new GuzzleAdapter(new Client());
  * configure options in example-options.json
  */
 $sparky = new SparkPost($httpClient, [
-    "key" => "YOUR_API_KEY",
-    // This will expose your API KEY - do not use this in production.
+    "key" => getenv('SPARKPOST_API_KEY'),
+    // fetch API KEY from environment variable
     "debug" => true
 ]);
 

--- a/examples/message-events/get_message_events.php
+++ b/examples/message-events/get_message_events.php
@@ -10,9 +10,11 @@ use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 
 $httpClient = new GuzzleAdapter(new Client());
 
-$sparky = new SparkPost($httpClient, ["key" => "YOUR_API_KEY",]);
+// In these examples, fetch API key from environment variable
+$sparky = new SparkPost($httpClient, ["key" => getenv('SPARKPOST_API_KEY')]);
 
-$promise = $sparky->request('GET', 'message-events', [
+// New endpoint - https://developers.sparkpost.com/api/events/
+$promise = $sparky->request('GET', 'events/message', [
     'campaign_ids' => 'CAMPAIGN_ID',
 ]);
 

--- a/examples/message-events/get_message_events_with_retry_logic.php
+++ b/examples/message-events/get_message_events_with_retry_logic.php
@@ -10,9 +10,11 @@ use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 
 $httpClient = new GuzzleAdapter(new Client());
 
-$sparky = new SparkPost($httpClient, ["key" => "YOUR_API_KEY", "retries" => 3]);
+// In these examples, fetch API key from environment variable
+$sparky = new SparkPost($httpClient, ["key" => getenv('SPARKPOST_API_KEY'), "retries" => 3]);
 
-$promise = $sparky->request('GET', 'message-events', [
+// New endpoint - https://developers.sparkpost.com/api/events/
+$promise = $sparky->request('GET', 'events/message', [
     'campaign_ids' => 'CAMPAIGN_ID',
 ]);
 

--- a/examples/templates/create_template.php
+++ b/examples/templates/create_template.php
@@ -10,14 +10,50 @@ use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 
 $httpClient = new GuzzleAdapter(new Client());
 
-$sparky = new SparkPost($httpClient, ["key" => "YOUR_API_KEY"]);
+// In these examples, fetch API key from environment variable
+$sparky = new SparkPost($httpClient, ["key" => getenv('SPARKPOST_API_KEY')]);
+
+$template_name = "PHP example template";
+$template_id = "PHP-example-template";
+
+// put your own sending domain here
+$sending_domain = "steve2-test.trymsys.net";
+
+// Valid short template content examples
+$plain_text = 'Write your text message part here.';
+
+$html = <<<HTML
+<!DOCTYPE html>
+<html lang="en">
+<body>
+  <p><strong>Write your HTML message part here</strong></p>
+</body>
+</html>
+HTML;
+
+$amp_html = <<<HTML
+<!doctype html>
+<html ⚡4email>
+<head>
+  <meta charset="utf-8">
+  <style amp4email-boilerplate>body{visibility:hidden}</style>
+  <script async src="https://cdn.ampproject.org/v0.js"></script>
+</head>
+<body>
+Hello World! Let's get started using AMP HTML together!
+</body>
+</html>
+HTML;
 
 $promise = $sparky->request('POST', 'templates', [
-  'name' => 'PHP example template',
+  'name' => $template_name,
+  'id' => $template_id,
   'content' => [
-    'from' => 'from@YOUR_DOMAIN',
+    'from' => "from@$sending_domain",
     'subject' => 'Your Subject',
-    'html' => '<b>Write your message here.</b>',
+    'text' => $plain_text,
+    'html' => $html,
+    'amp_html' => $amp_html,
   ],
 ]);
 

--- a/examples/templates/delete_template.php
+++ b/examples/templates/delete_template.php
@@ -10,9 +10,12 @@ use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 
 $httpClient = new GuzzleAdapter(new Client());
 
-$sparky = new SparkPost($httpClient, ["key" => "YOUR_API_KEY"]);
+// In these examples, fetch API key from environment variable
+$sparky = new SparkPost($httpClient, ["key" => getenv('SPARKPOST_API_KEY')]);
 
-$promise = $sparky->request('DELETE', 'templates/TEMPLATE_ID');
+$template_id = "PHP-example-template";
+
+$promise = $sparky->request('DELETE', "templates/$template_id");
 
 try {
     $response = $promise->wait();

--- a/examples/templates/get_all_templates.php
+++ b/examples/templates/get_all_templates.php
@@ -10,7 +10,8 @@ use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 
 $httpClient = new GuzzleAdapter(new Client());
 
-$sparky = new SparkPost($httpClient, ["key" => "YOUR_API_KEY"]);
+// In these examples, fetch API key from environment variable
+$sparky = new SparkPost($httpClient, ["key" => getenv('SPARKPOST_API_KEY')]);
 
 $promise = $sparky->request('GET', 'templates');
 

--- a/examples/templates/get_template.php
+++ b/examples/templates/get_template.php
@@ -10,9 +10,12 @@ use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 
 $httpClient = new GuzzleAdapter(new Client());
 
-$sparky = new SparkPost($httpClient, ["key" => "YOUR_API_KEY"]);
+// In these examples, fetch API key from environment variable
+$sparky = new SparkPost($httpClient, ["key" => getenv('SPARKPOST_API_KEY')]);
 
-$promise = $sparky->request('GET', 'templates/TEMPLATE_ID?draft=true');
+$template_id = "PHP-example-template";
+
+$promise = $sparky->request('GET', "templates/$template_id?draft=true");
 
 try {
     $response = $promise->wait();

--- a/examples/templates/preview_template.php
+++ b/examples/templates/preview_template.php
@@ -10,9 +10,12 @@ use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 
 $httpClient = new GuzzleAdapter(new Client());
 
-$sparky = new SparkPost($httpClient, ["key" => "YOUR_API_KEY"]);
+// In these examples, fetch API key from environment variable
+$sparky = new SparkPost($httpClient, ["key" => getenv('SPARKPOST_API_KEY')]);
 
-$promise = $sparky->request('POST', 'templates/TEMPLATE_ID/preview?draft=true', [
+$template_id = "PHP-example-template";
+
+$promise = $sparky->request('POST', "templates/$template_id/preview?draft=true", [
     'substitution_data' => [
         'some_key' => 'some_value',
     ],

--- a/examples/templates/update_template.php
+++ b/examples/templates/update_template.php
@@ -10,9 +10,12 @@ use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 
 $httpClient = new GuzzleAdapter(new Client());
 
-$sparky = new SparkPost($httpClient, ["key" => "YOUR_API_KEY"]);
+// In these examples, fetch API key from environment variable
+$sparky = new SparkPost($httpClient, ["key" => getenv('SPARKPOST_API_KEY')]);
 
-$promise = $sparky->request('PUT', 'templates/TEMPLATE_ID', [
+$template_id = "PHP-example-template";
+
+$promise = $sparky->request('PUT', "templates/$template_id", [
     'options' => [
         'open_tracking' => true,
     ],

--- a/examples/transmissions/create_transmission.php
+++ b/examples/transmissions/create_transmission.php
@@ -10,13 +10,18 @@ use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 
 $httpClient = new GuzzleAdapter(new Client());
 
-$sparky = new SparkPost($httpClient, ["key" => "YOUR_API_KEY"]);
+// In these examples, fetch API key from environment variable
+$sparky = new SparkPost($httpClient, ["key" => getenv('SPARKPOST_API_KEY')]);
+
+// put your own sending domain and test recipient address here
+$sending_domain = "steve2-test.trymsys.net";
+$your_email = "bob@sink.sparkpostmail.com";
 
 $promise = $sparky->transmissions->post([
     'content' => [
         'from' => [
             'name' => 'SparkPost Team',
-            'email' => 'from@sparkpostbox.com',
+            'email' => "from@$sending_domain",
         ],
         'subject' => 'First Mailing From PHP',
         'html' => '<html><body><h1>Congratulations, {{name}}!</h1><p>You just sent your very first mailing!</p></body></html>',
@@ -27,7 +32,7 @@ $promise = $sparky->transmissions->post([
         [
             'address' => [
                 'name' => 'YOUR_NAME',
-                'email' => 'YOUR_EMAIL',
+                'email' => $your_email,
             ],
         ],
     ],

--- a/examples/transmissions/create_transmission_with_attachment.php
+++ b/examples/transmissions/create_transmission_with_attachment.php
@@ -10,18 +10,23 @@ use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 
 $httpClient = new GuzzleAdapter(new Client());
 
-$sparky = new SparkPost($httpClient, ["key" => "YOUR_API_KEY"]);
+// In these examples, fetch API key from environment variable
+$sparky = new SparkPost($httpClient, ["key" => getenv('SPARKPOST_API_KEY')]);
 
 $filePath = dirname(__FILE__).'/';
 $fileName = 'sparkpost.png';
 $fileType = mime_content_type($filePath.$fileName);
 $fileData = base64_encode(file_get_contents($filePath.$fileName));
 
+// put your own sending domain and test recipient address here
+$sending_domain = "steve2-test.trymsys.net";
+$your_email = "bob@sink.sparkpostmail.com";
+
 $promise = $sparky->transmissions->post([
     'content' => [
         'from' => [
             'name' => 'SparkPost Team',
-            'email' => 'from@sparkpostbox.com',
+            'email' => "from@$sending_domain",
         ],
         'subject' => 'Mailing With Attachment From PHP',
         'html' => '<html><body><h1>Congratulations, {{name}}!</h1><p>You just sent an email with an attachment!</p></body></html>',
@@ -39,7 +44,7 @@ $promise = $sparky->transmissions->post([
         [
             'address' => [
                 'name' => 'YOUR_NAME',
-                'email' => 'YOUR_EMAIL',
+                'email' => $your_email,
             ],
         ],
     ],

--- a/examples/transmissions/create_transmission_with_cc_and_bcc.php
+++ b/examples/transmissions/create_transmission_with_cc_and_bcc.php
@@ -10,13 +10,20 @@ use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 
 $httpClient = new GuzzleAdapter(new Client());
 
-$sparky = new SparkPost($httpClient, ["key" => "YOUR_API_KEY"]);
+// In these examples, fetch API key from environment variable
+$sparky = new SparkPost($httpClient, ["key" => getenv('SPARKPOST_API_KEY')]);
+
+// put your own sending domain and test recipient address here
+$sending_domain = "steve2-test.trymsys.net";
+$your_email = "bob@sink.sparkpostmail.com";
+$your_cc = "alice@sink.sparkpostmail.com";
+$your_bcc = "charles@sink.sparkpostmail.com";
 
 $promise = $sparky->transmissions->post([
     'content' => [
         'from' => [
             'name' => 'SparkPost Team',
-            'email' => 'from@sparkpostbox.com',
+            'email' => "from@$sending_domain",
         ],
         'subject' => 'Mailing With CC and BCC From PHP',
         'html' => '<html><body><h1>Congratulations, {{name}}!</h1><p>You just sent your very first mailing with CC and BCC recipients!</p></body></html>',
@@ -27,7 +34,7 @@ $promise = $sparky->transmissions->post([
         [
             'address' => [
                 'name' => 'YOUR_NAME',
-                'email' => 'YOUR_EMAIL',
+                'email' => $your_email,
             ],
         ],
     ],
@@ -35,7 +42,7 @@ $promise = $sparky->transmissions->post([
         [
             'address' => [
                 'name' => 'ANOTHER_NAME',
-                'email' => 'ANOTHER_EMAIL',
+                'email' => $your_cc,
             ],
         ],
     ],
@@ -43,7 +50,7 @@ $promise = $sparky->transmissions->post([
         [
             'address' => [
                 'name' => 'AND_ANOTHER_NAME',
-                'email' => 'AND_ANOTHER_EMAIL',
+                'email' => $your_bcc,
             ],
         ],
     ],

--- a/examples/transmissions/create_transmission_with_recipient_list.php
+++ b/examples/transmissions/create_transmission_with_recipient_list.php
@@ -10,20 +10,27 @@ use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 
 $httpClient = new GuzzleAdapter(new Client());
 
-$sparky = new SparkPost($httpClient, ["key" => "YOUR_API_KEY"]);
+// In these examples, fetch API key from environment variable
+$sparky = new SparkPost($httpClient, ["key" => getenv('SPARKPOST_API_KEY')]);
+
+// put your own sending domain and test recipient address here
+$sending_domain = "steve2-test.trymsys.net";
+
+// The ID of a list in your SparkPost account
+$my_list = "mylist1";
 
 $promise = $sparky->transmissions->post([
     'content' => [
         'from' => [
             'name' => 'SparkPost Team',
-            'email' => 'from@sparkpostbox.com',
+            'email' => "from@$sending_domain",
         ],
         'subject' => 'Mailing With Recipient List From PHP',
         'html' => '<html><body><h1>Congratulations, {{name}}!</h1><p>You just sent an email to everyone on your recipient list!</p></body></html>',
         'text' => 'Congratulations, {{name}}! You just sent an email to everyone on your recipient list!',
     ],
     'substitution_data' => ['name' => 'YOUR_FIRST_NAME'],
-    'recipients' => ['list_id' => 'RECIPIENT_LIST_ID'],
+    'recipients' => ['list_id' => $my_list],
 ]);
 
 try {

--- a/examples/transmissions/create_transmission_with_template.php
+++ b/examples/transmissions/create_transmission_with_template.php
@@ -10,16 +10,23 @@ use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 
 $httpClient = new GuzzleAdapter(new Client());
 
-$sparky = new SparkPost($httpClient, ["key" => "YOUR_API_KEY"]);
+// In these examples, fetch API key from environment variable
+$sparky = new SparkPost($httpClient, ["key" => getenv('SPARKPOST_API_KEY')]);
+
+// put your own sending domain and test recipient address here
+$sending_domain = "steve2-test.trymsys.net";
+$your_email = "bob@sink.sparkpostmail.com";
+
+$template_id = "PHP-example-template";
 
 $promise = $sparky->transmissions->post([
-    'content' => ['template_id' => 'TEMPLATE_ID'],
+    'content' => ['template_id' => $template_id],
     'substitution_data' => ['name' => 'YOUR_FIRST_NAME'],
     'recipients' => [
         [
             'address' => [
                 'name' => 'YOUR_NAME',
-                'email' => 'YOUR_EMAIL',
+                'email' => $your_email,
             ],
         ],
     ],

--- a/examples/transmissions/delete_transmission.php
+++ b/examples/transmissions/delete_transmission.php
@@ -10,9 +10,13 @@ use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
 
 $httpClient = new GuzzleAdapter(new Client());
 
-$sparky = new SparkPost($httpClient, ["key" => "YOUR_API_KEY"]);
+// In these examples, fetch API key from environment variable
+$sparky = new SparkPost($httpClient, ["key" => getenv('SPARKPOST_API_KEY')]);
 
-$promise = $sparky->transmissions->delete('TRANSMISSION_ID');
+// Delete *scheduled* transmissions (only) by *campaign ID* (only)
+// See https://developers.sparkpost.com/api/transmissions/#transmissions-delete-delete-a-scheduled-transmission
+
+$promise = $sparky->transmissions->delete('?campaign_id=white_christmas');
 
 try {
     $response = $promise->wait();

--- a/examples/transmissions/get_all_transmissions.php
+++ b/examples/transmissions/get_all_transmissions.php
@@ -1,24 +1,3 @@
 <?php
-
-namespace Examples\Transmissions;
-
-require dirname(__FILE__).'/../bootstrap.php';
-
-use SparkPost\SparkPost;
-use GuzzleHttp\Client;
-use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
-
-$httpClient = new GuzzleAdapter(new Client());
-
-$sparky = new SparkPost($httpClient, ["key" => "YOUR_API_KEY"]);
-
-$promise = $sparky->transmissions->get();
-
-try {
-    $response = $promise->wait();
-    echo $response->getStatusCode()."\n";
-    print_r($response->getBody())."\n";
-} catch (\Exception $e) {
-    echo $e->getCode()."\n";
-    echo $e->getMessage()."\n";
-}
+// Feature has been deprecated
+// See https://developers.sparkpost.com/api/transmissions/#transmissions-get-retrieve-a-scheduled-transmission

--- a/examples/transmissions/get_transmission.php
+++ b/examples/transmissions/get_transmission.php
@@ -1,24 +1,3 @@
 <?php
-
-namespace Examples\Transmissions;
-
-require dirname(__FILE__).'/../bootstrap.php';
-
-use SparkPost\SparkPost;
-use GuzzleHttp\Client;
-use Http\Adapter\Guzzle6\Client as GuzzleAdapter;
-
-$httpClient = new GuzzleAdapter(new Client());
-
-$sparky = new SparkPost($httpClient, ["key" => "YOUR_API_KEY"]);
-
-$promise = $sparky->transmissions->get('TRANSMISSION_ID');
-
-try {
-    $response = $promise->wait();
-    echo $response->getStatusCode()."\n";
-    print_r($response->getBody())."\n";
-} catch (\Exception $e) {
-    echo $e->getCode()."\n";
-    echo $e->getMessage()."\n";
-}
+// Feature has been deprecated
+// See https://developers.sparkpost.com/api/transmissions/#transmissions-get-retrieve-a-scheduled-transmission

--- a/lib/SparkPost/SparkPost.php
+++ b/lib/SparkPost/SparkPost.php
@@ -13,7 +13,7 @@ class SparkPost
     /**
      * @var string Library version, used for setting User-Agent
      */
-    private $version = '2.2.0';
+    private $version = '2.3.0';
 
     /**
      * @var HttpClient|HttpAsyncClient used to make requests


### PR DESCRIPTION
Refresh the code examples
- Use SPARKPOST_API_KEY environment variable as input, rather than the example invalid string
- Update to use `events/message` endpoint
- Deprecate Transmission GET and DELETE by `transmission_id`. Add example of DELETE *scheduled* transmission *by campaign_id*
- Test each example