### PR TITLE
Require php-http/message-factory

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -17,7 +17,8 @@
     "php-http/httplug": "^1.0 || ^2.0",
     "php-http/message": "^1.0",
     "php-http/client-implementation": "^1.0",
-    "php-http/discovery": "^1.0"
+    "php-http/discovery": "^1.0",
+    "php-http/message-factory": "^1.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^8.0 || ^9.0",


### PR DESCRIPTION
This library is needed to send the messages through sparkpost. It was initially required by php-http/message , but since version 1.16.0 it is not required anymore by the package and it must be required manually for the libraries using it.